### PR TITLE
exporting textacy/spacy objects into "third-party" formats

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+Changelog
+=========
+
+0.2.0 (WIP)
+-----------
+
+Changes:
+
+- Added ``export.py`` module for exporting textacy/spacy objects into "third-party" formats; so far, just gensim and conll-u.
+
+Bug fixes:
+
+- Whitespace tokens now always filtered out of ``extract.words()`` lists.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cld2-cffi
 cytoolz
 ftfy
 fuzzywuzzy
+gensim
 networkx
 nltk
 numpy>=1.8.0

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 import numpy as np
 import unittest
 
+from spacy import attrs
+
 from textacy import data, export
 
 class ExportTestCase(unittest.TestCase):
@@ -22,9 +24,27 @@ class ExportTestCase(unittest.TestCase):
             [433, -3, 363], [432, -1, 405], [441, -1, 401], [424, -1, 372], [426, 1, 379],
             [440, -3, 375], [419, -9, 407], [445, 1, 393], [455, 0, 53503], [433, -1, 363],
             [426, 2, 379], [460, 1, 379], [440, -4, 392], [419, -5, 407]], dtype='int32')
-        self.spacy_doc.from_array(cols, vals)
+        self.spacy_doc.from_array(cols, values)
 
     def test_doc_to_conll(self):
         expected = "# sent_id 1\n1\tThe\tthe\tDET\tDT\t_\t2\tdet\t_\t_\n2\tyear\tyear\tNOUN\tNN\t_\t3\tnsubj\t_\t_\n3\twas\tbe\tVERB\tVBD\t_\t0\troot\t_\t_\n4\t2081\t2081\tNUM\tCD\t_\t3\tattr\t_\tSpaceAfter=No\n5\t,\t,\tPUNCT\t,\t_\t3\tpunct\t_\t_\n6\tand\tand\tCONJ\tCC\t_\t3\tcc\t_\t_\n7\teverybody\teverybody\tNOUN\tNN\t_\t8\tnsubj\t_\t_\n8\twas\tbe\tVERB\tVBD\t_\t3\tconj\t_\t_\n9\tfinally\tfinally\tADV\tRB\t_\t8\tadvmod\t_\t_\n10\tequal\tequal\tADJ\tJJ\t_\t8\tacomp\t_\tSpaceAfter=No\n11\t.\t.\tPUNCT\t.\t_\t8\tpunct\t_\t_\n\n# sent_id 2\n1\tThey\tthey\tNOUN\tPRP\t_\t2\tnsubj\t_\t_\n2\twere\tbe\tVERB\tVBD\t_\t0\troot\t_\tSpaceAfter=No\n3\tn't\tn't\tADV\tRB\t_\t5\tpreconj\t_\t_\n4\tonly\tonly\tADV\tRB\t_\t3\tadvmod\t_\t_\n5\tequal\tequal\tADJ\tJJ\t_\t2\tacomp\t_\t_\n6\tbefore\tbefore\tADP\tIN\t_\t5\tprep\t_\t_\n7\tGod\tgod\tNOUN\tNNP\t_\t6\tpobj\t_\t_\n8\tand\tand\tCONJ\tCC\t_\t7\tcc\t_\t_\n9\tthe\tthe\tDET\tDT\t_\t10\tdet\t_\t_\n10\tlaw\tlaw\tNOUN\tNN\t_\t7\tconj\t_\tSpaceAfter=No\n11\t.\t.\tPUNCT\t.\t_\t2\tpunct\t_\t_\n\n# sent_id 3\n1\tThey\tthey\tNOUN\tPRP\t_\t2\tnsubj\t_\t_\n2\twere\tbe\tVERB\tVBD\t_\t0\troot\t_\t_\n3\tequal\tequal\tADJ\tJJ\t_\t2\tacomp\t_\t_\n4\tevery\tevery\tDET\tDT\t_\t6\tdet\t_\t_\n5\twhich\twhich\tADJ\tWDT\t_\t6\tdet\t_\t_\n6\tway\tway\tNOUN\tNN\t_\t2\tnpadvmod\t_\tSpaceAfter=No\n7\t.\t.\tPUNCT\t.\t_\t2\tpunct\t_\tSpaceAfter=No\n"
         observed = export.doc_to_conll(self.spacy_doc)
         self.assertEqual(observed, expected)
+
+    def test_doc_to_gensim(self):
+        expected_gdoc = [(0, 1), (1, 1), (2, 1), (3, 3), (4, 1), (5, 1), (6, 1),
+                         (7, 1), (8, 1)]
+        expected_gdict = {0: 'year', 1: '2081', 2: 'law', 3: 'equal', 4: 'finally',
+                          5: 'way', 6: 'everybody', 7: "n't", 8: 'god'}
+        observed_gdict, observed_gdoc = export.doc_to_gensim(
+            self.spacy_doc, lemmatize=True,
+            filter_stops=True, filter_punct=True, filter_nums=False)
+        observed_gdict = dict(observed_gdict)
+
+        self.assertEqual(len(observed_gdoc), len(expected_gdoc))
+        self.assertEqual(len(observed_gdict), len(expected_gdict))
+        # ensure counts are the same for each unique token
+        for exp_tok_id, exp_tok_str in expected_gdict.items():
+            obs_tok_id = [tok_id for tok_id, tok_str in observed_gdict.items()
+                          if tok_str == exp_tok_str][0]
+            self.assertEqual(observed_gdoc[obs_tok_id][1], expected_gdoc[exp_tok_id][1])

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, unicode_literals
+
+import numpy as np
+import unittest
+
+from textacy import data, export
+
+class ExportTestCase(unittest.TestCase):
+
+    def setUp(self):
+        text = "The year was 2081, and everybody was finally equal. They weren't only equal before God and the law. They were equal every which way."
+        # we're not loading all models for speed; instead, we're updating the doc
+        # with pre-computed part-of-speech tagging and parsing values
+        spacy_pipeline = data.load_spacy_pipeline(
+            lang='en', tagger=False, parser=False, entity=False, matcher=False)
+        self.spacy_doc = spacy_pipeline(text)
+        cols = [attrs.TAG, attrs.HEAD, attrs.DEP]
+        values = np.array(
+            [[426, 1, 379], [440, 1, 393], [455, 0, 53503], [425, -1, 369], [416, -2, 407],
+            [424, -3, 372], [440, 1, 393], [455, -5, 375], [447, -1, 365], [433, -2, 363],
+            [419, -3, 407], [445, 1, 393], [455, 0, 53503], [447, 2, 404], [447, -1, 365],
+            [433, -3, 363], [432, -1, 405], [441, -1, 401], [424, -1, 372], [426, 1, 379],
+            [440, -3, 375], [419, -9, 407], [445, 1, 393], [455, 0, 53503], [433, -1, 363],
+            [426, 2, 379], [460, 1, 379], [440, -4, 392], [419, -5, 407]], dtype='int32')
+        self.spacy_doc.from_array(cols, vals)
+
+    def test_doc_to_conll(self):
+        expected = "# sent_id 1\n1\tThe\tthe\tDET\tDT\t_\t2\tdet\t_\t_\n2\tyear\tyear\tNOUN\tNN\t_\t3\tnsubj\t_\t_\n3\twas\tbe\tVERB\tVBD\t_\t0\troot\t_\t_\n4\t2081\t2081\tNUM\tCD\t_\t3\tattr\t_\tSpaceAfter=No\n5\t,\t,\tPUNCT\t,\t_\t3\tpunct\t_\t_\n6\tand\tand\tCONJ\tCC\t_\t3\tcc\t_\t_\n7\teverybody\teverybody\tNOUN\tNN\t_\t8\tnsubj\t_\t_\n8\twas\tbe\tVERB\tVBD\t_\t3\tconj\t_\t_\n9\tfinally\tfinally\tADV\tRB\t_\t8\tadvmod\t_\t_\n10\tequal\tequal\tADJ\tJJ\t_\t8\tacomp\t_\tSpaceAfter=No\n11\t.\t.\tPUNCT\t.\t_\t8\tpunct\t_\t_\n\n# sent_id 2\n1\tThey\tthey\tNOUN\tPRP\t_\t2\tnsubj\t_\t_\n2\twere\tbe\tVERB\tVBD\t_\t0\troot\t_\tSpaceAfter=No\n3\tn't\tn't\tADV\tRB\t_\t5\tpreconj\t_\t_\n4\tonly\tonly\tADV\tRB\t_\t3\tadvmod\t_\t_\n5\tequal\tequal\tADJ\tJJ\t_\t2\tacomp\t_\t_\n6\tbefore\tbefore\tADP\tIN\t_\t5\tprep\t_\t_\n7\tGod\tgod\tNOUN\tNNP\t_\t6\tpobj\t_\t_\n8\tand\tand\tCONJ\tCC\t_\t7\tcc\t_\t_\n9\tthe\tthe\tDET\tDT\t_\t10\tdet\t_\t_\n10\tlaw\tlaw\tNOUN\tNN\t_\t7\tconj\t_\tSpaceAfter=No\n11\t.\t.\tPUNCT\t.\t_\t2\tpunct\t_\t_\n\n# sent_id 3\n1\tThey\tthey\tNOUN\tPRP\t_\t2\tnsubj\t_\t_\n2\twere\tbe\tVERB\tVBD\t_\t0\troot\t_\t_\n3\tequal\tequal\tADJ\tJJ\t_\t2\tacomp\t_\t_\n4\tevery\tevery\tDET\tDT\t_\t6\tdet\t_\t_\n5\twhich\twhich\tADJ\tWDT\t_\t6\tdet\t_\t_\n6\tway\tway\tNOUN\tNN\t_\t2\tnpadvmod\t_\tSpaceAfter=No\n7\t.\t.\tPUNCT\t.\t_\t2\tpunct\t_\tSpaceAfter=No\n"
+        observed = export.doc_to_conll(self.spacy_doc)
+        self.assertEqual(observed, expected)

--- a/textacy/export.py
+++ b/textacy/export.py
@@ -1,0 +1,72 @@
+"""
+Module for exporting textacy/spacy objects into "third-party" formats.
+"""
+from gensim.corpora.dictionary import Dictionary
+
+from textacy import extract
+
+
+def doc_to_gensim(doc, lemmatize=True,
+                  filter_stops=True, filter_punct=True, filter_nums=False):
+    """
+    Convert a single ``spacy.Doc`` into a gensim dictionary and bag-of-words document.
+
+    Args:
+        doc (``spacy.Doc``)
+        lemmatize (bool): if True, use lemmatized strings for words; otherwise,
+            use the original form of the string as it appears in ``doc``
+        filter_stops (bool): if True, remove stop words from word list
+        filter_punct (bool): if True, remove punctuation from word list
+        filter_nums (bool): if True, remove numbers from word list
+
+    Returns:
+        :class:`gensim.Dictionary <gensim.corpora.dictionary.Dictionary>`:
+            integer word ID to word string mapping
+        list((int, int)): bag-of-words document, a list of (integer word ID, word count)
+            2-tuples
+    """
+    gdict = Dictionary()
+    words = extract.words(doc,
+                          filter_stops=filter_stops,
+                          filter_punct=filter_punct,
+                          filter_nums=filter_nums)
+    if lemmatize is True:
+        gdoc = gdict.doc2bow((word.lemma_ for word in words), allow_update=True)
+    else:
+        gdoc = gdict.doc2bow((word.orth_ for word in words), allow_update=True)
+
+    return (gdict, gdoc)
+
+
+def docs_to_gensim(docs, lemmatize=True,
+                   filter_stops=True, filter_punct=True, filter_nums=False):
+    """
+    Convert multiple ``spacy.Doc`` s into a gensim dictionary and bag-of-words corpus.
+
+    Args:
+        docs (list(``spacy.Doc``))
+        lemmatize (bool): if True, use lemmatized strings for words; otherwise,
+            use the original form of the string as it appears in ``doc``
+        filter_stops (bool): if True, remove stop words from word list
+        filter_punct (bool): if True, remove punctuation from word list
+        filter_nums (bool): if True, remove numbers from word list
+
+    Returns:
+        :class:`gensim.Dictionary <gensim.corpora.dictionary.Dictionary>`:
+            integer word ID to word string mapping
+        list(list((int, int))): list of bag-of-words documents, where each doc is
+            a list of (integer word ID, word count) 2-tuples
+    """
+    gdict = Dictionary()
+    gcorpus = []
+    for doc in docs:
+        words = extract.words(doc,
+                              filter_stops=filter_stops,
+                              filter_punct=filter_punct,
+                              filter_nums=filter_nums)
+        if lemmatize is True:
+            gcorpus.append(gdict.doc2bow((word.lemma_ for word in words), allow_update=True))
+        else:
+            gcorpus.append(gdict.doc2bow((word.orth_ for word in words), allow_update=True))
+
+    return (gdict, gcorpus)

--- a/textacy/export.py
+++ b/textacy/export.py
@@ -85,6 +85,9 @@ def doc_to_conll(doc, save_to=False):
 
     Returns:
         str or None
+
+    Notes:
+        See http://universaldependencies.org/docs/format.html for details.
     """
     rows = []
     for j, sent in enumerate(doc.sents):

--- a/textacy/export.py
+++ b/textacy/export.py
@@ -1,6 +1,8 @@
 """
 Module for exporting textacy/spacy objects into "third-party" formats.
 """
+import io
+
 from gensim.corpora.dictionary import Dictionary
 
 from textacy import extract
@@ -70,3 +72,44 @@ def docs_to_gensim(docs, lemmatize=True,
             gcorpus.append(gdict.doc2bow((word.orth_ for word in words), allow_update=True))
 
     return (gdict, gcorpus)
+
+
+def doc_to_conll(doc, save_to=False):
+    """
+    Convert a single ``spacy.Doc`` into CoNLL-U string format, optionally saving to disk.
+
+    Args:
+        doc (``spacy.Doc``)
+        save_to (str, optional): to save the CoNLL string to disk, provide the full
+            path/to/fname.txt; otherwise, the string is returned but not saved
+
+    Returns:
+        str or None
+    """
+    rows = []
+    for j, sent in enumerate(doc.sents):
+        sent_i = sent.start
+        sent_id = j + 1
+        rows.append('# sent_id {}'.format(sent_id))
+        for i, tok in enumerate(sent):
+            # HACK...
+            if tok.is_space:
+                form = ' '
+                lemma = ' '
+            else:
+                form = tok.orth_
+                lemma = tok.lemma_
+            tok_id = i + 1
+            head = tok.head.i - sent_i + 1
+            if head == tok_id:
+                head = 0
+            misc = 'SpaceAfter=No' if not tok.whitespace_ else '_'
+            rows.append('\t'.join([str(tok_id), form, lemma, tok.pos_, tok.tag_,
+                                   '_', str(head), tok.dep_.lower(), '_', misc]))
+        rows.append('')  # sentences must be separated by a single newline
+    conll = '\n'.join(rows)
+    if save_to is False:
+        return conll
+    else:
+        with io.open(save_to, mode='w', encoding='utf-8') as f:
+            f.write(conll)

--- a/textacy/extract.py
+++ b/textacy/extract.py
@@ -46,7 +46,7 @@ def words(doc,
     Returns:
         list[``spacy.Token``]
     """
-    words_ = (w for w in doc)
+    words_ = (w for w in doc if not w.is_space)
     if filter_stops is True:
         words_ = (w for w in words_ if not w.is_stop)
     if filter_punct is True:


### PR DESCRIPTION
- added a CHANGELOG to the repo
- added the `export.py` module for exporting textacy/spacy objects into "third-party" formats, currently just gensim dict + bow doc and conll string formats
- added a test for the conll format, undecided on gensim format tests at the moment

help me, @danvalente, you're my only hope.