### PR TITLE
added (str) term cleaning function and tests

### DIFF
--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -11,6 +11,14 @@ GOOD_ACRONYMS = [
 BAD_ACRONYMS = [
     'A', 'GHz', '1a', 'D o E', 'Ms', 'Ph.D', '3-Dim.', 'the', 'FooBar', '1', ' ', '']
 
+CRUFTY_TERMS = ['( foo bar )',
+                'foo -bar', '- 123.4',
+                '.-foo bar', '?!foo', 'bar?!',
+                "foo 's bar", "foo 'll bar",
+                '  foo   bar   ', 'foo bar.   ']
+GOOD_TERMS = ['foo (bar)', 'foo?', 'bar!', '-123.4']
+BAD_TERMS = ['(foo bar', 'foo) bar', '?>,!-.', '', 'foo) (bar']
+
 LANG_SENTS = [
     ('en', 'This sentence is in English.'),
     ('es', 'Esta oración es en Español.'),
@@ -84,3 +92,17 @@ class TextUtilsTestCase(unittest.TestCase):
         expected = [('No llores porque ya se ', 'terminó', ', sonríe porque sucedió.')]
         for o, e in zip(observed, expected):
             self.assertEqual(o, e)
+
+    def test_clean_terms_good(self):
+        observed = list(text_utils.clean_terms(GOOD_TERMS))
+        self.assertEqual(observed, GOOD_TERMS)
+
+    def test_clean_terms_bad(self):
+        observed = list(text_utils.clean_terms(BAD_TERMS))
+        self.assertEqual(observed, [])
+
+    def test_clean_terms_crufty(self):
+        observed = list(text_utils.clean_terms(CRUFTY_TERMS))
+        expected = ['(foo bar)', 'foo-bar', '-123.4', 'foo bar', 'foo', 'bar?!',
+                    "foo's bar", "foo'll bar", 'foo bar', 'foo bar.']
+        self.assertEqual(observed, expected)

--- a/textacy/regexes_etc.py
+++ b/textacy/regexes_etc.py
@@ -86,3 +86,12 @@ SHORT_URL_REGEX = re.compile(
     r"[^\s.,?!'\"|+]{2,12}"
     r"(?:$|(?![\w?!+&/]))"
     , flags=re.IGNORECASE)
+
+# regexes for cleaning up crufty terms
+DANGLING_PARENS_TERM_RE = re.compile(r'(?:\s|^)(\()\s{1,2}(.*?)\s{1,2}(\))(?:\s|$)',
+                                     flags=re.UNICODE)
+LEAD_TAIL_CRUFT_TERM_RE = re.compile(r'^([^\w(-] ?)+|([^\w).!?] ?)+$', flags=re.UNICODE)
+LEAD_HYPHEN_TERM_RE = re.compile(r'^-([^\W\d_])', flags=re.UNICODE)
+NEG_DIGIT_TERM_RE = re.compile(r'(-) (\d)', flags=re.UNICODE)
+WEIRD_HYPHEN_SPACE_TERM_RE = re.compile(r'(?<=[^\W\d]) (-[^\W\d])', flags=re.UNICODE)
+WEIRD_APOSTR_SPACE_TERM_RE = re.compile(r"([^\W\d]+) ('[a-z]{1,2}\b)", flags=re.UNICODE)


### PR DESCRIPTION
Pretty straightforward application of regexes to clean up common cruft from extracted single- or multi-word terms, such as you might get from the functions in `textacy.keyterms`.

Could you spare a glance, @danvalente?