### PR TITLE
addition of the viz subpackage

### DIFF
--- a/textacy/__init__.py
+++ b/textacy/__init__.py
@@ -11,6 +11,7 @@ from textacy import corpora
 from textacy import fileio
 from textacy import representations
 from textacy import tm
+from textacy import viz
 # top-level modules
 from textacy import compat, data, math_utils, regexes_etc
 from textacy import lexicon_methods, preprocess, text_stats, text_utils

--- a/textacy/fileio/__init__.py
+++ b/textacy/fileio/__init__.py
@@ -1,7 +1,7 @@
 from .read import (read_json, read_json_lines, read_json_mash,
                    read_file, read_file_lines, read_spacy_docs,
                    read_sparse_csr_matrix, read_sparse_csc_matrix,
-                   get_filenames)
+                   get_filenames, split_content_and_metadata)
 from .write import (write_json, write_json_lines,
                     write_file, write_file_lines, write_spacy_docs,
                     write_conll, write_sparse_matrix)

--- a/textacy/tm/topic_model.py
+++ b/textacy/tm/topic_model.py
@@ -300,7 +300,8 @@ class TopicModel(object):
 
     def termite_plot(self, doc_term_matrix, id2term,
                      topics=-1, sort_topics_by='weight', highlight_topics=None,
-                     n_terms=25, top_terms_by='topic_weight', sort_terms_by='seriation'):
+                     n_terms=25, rank_terms_by='topic_weight', sort_terms_by='seriation',
+                     save=False):
         """
         Make a "termite" plot for assessing topic models using a tabular layout
         to promote comparison of terms both within and across topics.
@@ -320,19 +321,20 @@ class TopicModel(object):
             highlight_topics (seq(int) or int, optional): indices for up to 6 topics
                 to visually highlight in the plot with contrasting colors
             n_terms (int, optional): number of top terms to include in termite plot
-            top_terms_by ({'topic_weight', 'corpus_weight'}, optional): value used
+            rank_terms_by ({'topic_weight', 'corpus_weight'}, optional): value used
                 to rank terms; the top-ranked ``n_terms`` are included in the plot
             sort_terms_by ({'seriation', 'weight', 'index', 'alphabetical'}, optional):
                 method used to vertically sort the selected top ``n_terms`` terms;
                 the default ("seriation") groups similar terms together, which
                 facilitates cross-topic assessment
+            save (str, optional): give the full /path/to/fname on disk to save figure
 
         Returns:
             ``matplotlib.axes.Axes.axis``: axis on which termite plot is plotted
 
         Raises:
             ValueError: if more than 6 topics are selected for highlighting, or
-                an invalid value is passed for the sort_topics_by, top_terms_by,
+                an invalid value is passed for the sort_topics_by, rank_terms_by,
                 and/or sort_terms_by params
 
         References:
@@ -341,6 +343,10 @@ class TopicModel(object):
                 Proceedings of the International Working Conference on Advanced
                 Visual Interfaces. ACM, 2012.
             .. for sorting by "seriation", see https://arxiv.org/abs/1406.5370
+
+        .. seealso:: :func:`viz.termite_plot <textacy.viz.termite.termite_plot>`
+
+        TODO: `rank_terms_by` other metrics, e.g. topic salience or relevance
         """
         if highlight_topics is not None:
             if isinstance(highlight_topics, int):
@@ -373,12 +379,12 @@ class TopicModel(object):
                                if topic_inds[i] in highlight_topics)
 
         # get top term indices
-        if top_terms_by == 'corpus_weight':
+        if rank_terms_by == 'corpus_weight':
             term_inds = np.argsort(np.ravel(doc_term_matrix.sum(axis=0)))[:-n_terms - 1:-1]
-        elif top_terms_by == 'topic_weight':
+        elif rank_terms_by == 'topic_weight':
             term_inds = np.argsort(self.model.components_.sum(axis=0))[:-n_terms - 1:-1]
         else:
-            msg = 'invalid top_terms_by value; must be in {}'.format(
+            msg = 'invalid rank_terms_by value; must be in {}'.format(
                 {'corpus_weight', 'topic_weight'})
             raise ValueError(msg)
 
@@ -420,4 +426,4 @@ class TopicModel(object):
 
         return viz.termite_plot(
             term_topic_weights, topic_labels, term_labels,
-            highlight_cols=highlight_cols)
+            highlight_cols=highlight_cols, save=save)

--- a/textacy/tm/topic_model.py
+++ b/textacy/tm/topic_model.py
@@ -356,8 +356,6 @@ class TopicModel(object):
                 highlight_topics = (highlight_topics,)
             elif len(highlight_topics) > 6:
                 raise ValueError('no more than 6 topics may be highlighted at once')
-        else:
-            highlight_topics = tuple()
 
         # get topics indices
         if topics == -1:
@@ -380,8 +378,11 @@ class TopicModel(object):
             raise ValueError(msg)
 
         # get column index of any topics to highlight in termite plot
-        highlight_cols = tuple(i for i in range(len(topic_inds))
-                               if topic_inds[i] in highlight_topics)
+        if highlight_topics is not None:
+            highlight_cols = tuple(i for i in range(len(topic_inds))
+                                   if topic_inds[i] in highlight_topics)
+        else:
+            highlight_cols = None
 
         # get top term indices
         if rank_terms_by == 'corpus_weight':

--- a/textacy/tm/topic_model.py
+++ b/textacy/tm/topic_model.py
@@ -302,7 +302,7 @@ class TopicModel(object):
     #     raise NotImplementedError()
 
     def termite_plot(self, doc_term_matrix, id2term,
-                     topics=-1, sort_topics_by='weight', highlight_topics=None,
+                     topics=-1, sort_topics_by='index', highlight_topics=None,
                      n_terms=25, rank_terms_by='topic_weight', sort_terms_by='seriation',
                      save=False):
         """
@@ -356,6 +356,8 @@ class TopicModel(object):
                 highlight_topics = (highlight_topics,)
             elif len(highlight_topics) > 6:
                 raise ValueError('no more than 6 topics may be highlighted at once')
+        else:
+            highlight_topics = tuple()
 
         # get topics indices
         if topics == -1:
@@ -427,6 +429,6 @@ class TopicModel(object):
         term_topic_weights = np.array([self.model.components_[topic_ind][term_inds]
                                       for topic_ind in topic_inds]).T
 
-        return viz.termite_plot(
+        return viz.draw_termite_plot(
             term_topic_weights, topic_labels, term_labels,
             highlight_cols=highlight_cols, save=save)

--- a/textacy/tm/topic_model.py
+++ b/textacy/tm/topic_model.py
@@ -19,17 +19,20 @@ Train and apply a topic model to vectorized texts. For example::
     >>> # transform the corpus and interpret our model
     >>> doc_topic_matrix = model.transform(doc_term_matrix)
     >>> for topic_idx, top_terms in model.top_topic_terms(id2term, top_n=10):
-    ...     print('topic {}:'.format(topic_idx), '   '.join(top_terms))
+    ...     print('topic', topic_idx, ':', '   '.join(top_terms))
     >>> for topic_idx, top_docs in model.top_topic_docs(doc_topic_matrix, top_n=5):
-    ...     print('\n{}'.format(topic_idx))
+    ...     print(topic_idx)
     ...     for j in top_docs:
     ...         print(corpus[j].metadata['title'])
     >>> for doc_idx, topics in model.top_doc_topics(doc_topic_matrix, docs=range(5), top_n=2):
-    ...     print('{}: {}'.format(corpus[doc_idx].metadata['title'], topics))
+    ...     print(corpus[doc_idx].metadata['title'], ':', topics)
     >>> for i, val in enumerate(model.topic_weights(doc_topic_matrix)):
     ...     print(i, val)
+    >>> # visualize the model
+    >>> model.termite_plot(doc_term_matrix, id2term,
+    ...                    topics=-1,  n_terms=25, sort_terms_by='seriation')
     >>> # assess topic quality through a coherence metric
-    >>> # WIP...
+    >>> # TODO...
     >>> # persist our topic model to disk
     >>> model.save('nmf-20topics.pkl')
 """

--- a/textacy/tm/topic_model.py
+++ b/textacy/tm/topic_model.py
@@ -33,10 +33,15 @@ Train and apply a topic model to vectorized texts. For example::
     >>> # persist our topic model to disk
     >>> model.save('nmf-20topics.pkl')
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import logging
+
 import numpy as np
 from sklearn.decomposition import NMF, LatentDirichletAllocation, TruncatedSVD
 from sklearn.externals import joblib
+
+from textacy import viz
 
 
 logger = logging.getLogger(__name__)
@@ -292,3 +297,98 @@ class TopicModel(object):
     #
     # def get_model_coherence(self):
     #     raise NotImplementedError()
+
+    def termite_plot(self, doc_term_matrix, id2term,
+                     topics=-1, sort_topics_by='weight', highlight_topics=None,
+                     n_terms=25, top_terms_by='topic_weight', sort_terms_by='seriation'):
+        """
+        Args:
+            doc_term_matrix (``np.ndarray``-like)
+            id2term (list(str) or dict): object that returns the term string corresponding
+                to term id ``i`` through ``id2term[i]``; could be a list of strings
+                where the index represents the term id, such as that returned by
+                ``sklearn.feature_extraction.text.CountVectorizer.get_feature_names()``,
+                or a mapping of term id: term string
+            topics (seq(int) or int, optional): topic(s) to include in termite plot;
+                if -1, all topics are included
+            sort_topics_by ({'index', 'weight'}, optional)
+            highlight_topics (seq(int) or int, optional)
+            n_terms (int, optional)
+            top_terms_by ({'topic_weight', 'corpus_weight'}, optional)
+            sort_terms_by ({'seriation', 'weight', 'index', 'alphabetical'}, optional)
+        """
+        if highlight_topics is not None:
+            if isinstance(highlight_topics, int):
+                highlight_topics = (highlight_topics,)
+            elif len(highlight_topics) > 6:
+                raise ValueError('no more than 6 topics may be highlighted at once')
+
+        # get topics indices
+        if topics == -1:
+            topic_inds = tuple(range(self.n_topics))
+        elif isinstance(topics, int):
+            topic_inds = (topics,)
+        else:
+            topic_inds = tuple(topics)
+
+        # get topic indices in sorted order
+        if sort_topics_by == 'index':
+            topic_inds = sorted(topic_inds)
+        elif sort_topics_by == 'weight':
+            topic_inds = tuple(topic_ind for topic_ind
+                               in np.argsort(self.topic_weights(self.transform(doc_term_matrix)))[::-1]
+                               if topic_ind in topic_inds)
+        else:
+            raise ValueError()
+
+        # get column index of any topics to highlight in termite plot
+        highlight_cols = tuple(i for i in range(len(topic_inds))
+                               if topic_inds[i] in highlight_topics)
+
+        # get top term indices
+        if top_terms_by == 'corpus_weight':
+            term_inds = np.argsort(np.ravel(doc_term_matrix.sum(axis=0)))[:-n_terms - 1:-1]
+        elif top_terms_by == 'topic_weight':
+            term_inds = np.argsort(self.model.components_.sum(axis=0))[:-n_terms - 1:-1]
+        else:
+            raise ValueError()
+
+        # get top term indices in sorted order
+        if sort_terms_by == 'weight':
+            pass
+        elif sort_terms_by == 'index':
+            term_inds = sorted(term_inds)
+        elif sort_terms_by == 'alphabetical':
+            term_inds = sorted(term_inds, key=lambda x: id2term[x])
+        elif sort_terms_by == 'seriation':
+            # https://arxiv.org/abs/1406.5370
+            topic_term_weights_mat = np.array(
+                np.array([self.model.components_[topic_ind][term_inds]
+                          for topic_ind in topic_inds])).T
+            # calculate similarity matrix
+            topic_term_weights_sim = np.dot(topic_term_weights_mat, topic_term_weights_mat.T)
+            # substract minimum of sim mat in order to keep sim mat nonnegative
+            topic_term_weights_sim = topic_term_weights_sim - topic_term_weights_sim.min()
+            # compute Laplacian matrice and its 2nd eigenvector
+            L = np.diag(sum(topic_term_weights_sim, 1)) - topic_term_weights_sim
+            D, V = np.linalg.eigh(L)
+            D = D[np.argsort(D)]
+            V = V[:, np.argsort(D)]
+            fiedler = V[:, 1]
+            # get permutation corresponding to sorting the 2nd eigenvector
+            term_inds = [term_inds[i] for i in np.argsort(fiedler)]
+        else:
+            raise ValueError()
+
+        # get topic and term labels
+        topic_labels = tuple('topic {}'.format(topic_ind) for topic_ind in topic_inds)
+        term_labels = tuple(id2term[term_ind] for term_ind in term_inds)
+
+        # get topic-term weights to size dots
+        term_topic_weights = np.array([self.model.components_[topic_ind][term_inds]
+                                      for topic_ind in topic_inds]).T
+
+        #return (term_topic_weights, topic_labels, term_labels, highlight_cols)
+
+        ax = viz.termite_plot(
+            term_topic_weights, topic_labels, term_labels, highlight_cols=highlight_cols)

--- a/textacy/viz/__init__.py
+++ b/textacy/viz/__init__.py
@@ -1,0 +1,1 @@
+from .termite import termite_plot

--- a/textacy/viz/__init__.py
+++ b/textacy/viz/__init__.py
@@ -1,1 +1,4 @@
 from .termite import termite_plot
+
+# TODO
+# - interactive versions of all plots

--- a/textacy/viz/__init__.py
+++ b/textacy/viz/__init__.py
@@ -1,4 +1,5 @@
-from .termite import termite_plot
+from .network import draw_semantic_network
+from .termite import draw_termite_plot
 
 # TODO
 # - interactive versions of all plots

--- a/textacy/viz/network.py
+++ b/textacy/viz/network.py
@@ -29,8 +29,10 @@ RC_PARAMS = {'axes.axisbelow': True,
              'ytick.major.size': 0.0, 'ytick.minor.size': 0.0}
 
 
-def draw_semantic_network(graph, node_weights=None, draw_nodes=False,
-                          save=False):
+def draw_semantic_network(graph, node_weights=None, spread=3.0,
+                          draw_nodes=False, base_node_size=300, node_alpha=0.25,
+                          line_width=0.5, line_alpha=0.1,
+                          base_font_size=12, save=False):
     """
     Draw a semantic network with nodes representing either terms or sentences,
     edges representing coocurrence or similarity, and positions given by a force-
@@ -40,7 +42,20 @@ def draw_semantic_network(graph, node_weights=None, draw_nodes=False,
         graph (:class:`networkx.Graph <networkx.Graph>`):
         node_weights (dict): mapping of node: weight, used to size node labels
             (and, optionally, node circles) according to their weight
+        spread (float): number that drives the spread of the network; higher
+            values give more spread-out networks
         draw_nodes (bool): if True, circles are drawn under the node labels
+        base_node_size (int): if `node_weights` not given and `draw_nodes` is True,
+            this is the size of all nodes in the network; if `node_weights` _is_
+            given, node sizes will be scaled against this value based on their
+            weights compared to the max weight
+        node_alpha (float): alpha of the circular nodes drawn behind labels if
+            `draw_nodes` is True
+        line_width (float): width of the lines (edges) drawn between nodes
+        line_alpha (float): alpha of the lines (edges) drawn between nodes
+        base_font_size (int): if `node_weights` not given, this is the font size
+            used to draw all labels; otherwise, font sizes will be scaled against
+            this value based on the corresponding node weights compared to the max
         save (str): give the full /path/to/fname on disk to save figure (optional)
 
     Returns:
@@ -49,26 +64,29 @@ def draw_semantic_network(graph, node_weights=None, draw_nodes=False,
     with plt.rc_context(RC_PARAMS):
         fig, ax = plt.subplots(figsize=(12, 12))
 
-        pos = nx.layout.spring_layout(graph, k=2.5/math.sqrt(len(graph.nodes())))
-        _ = nx.draw_networkx_edges(graph, ax=ax, alpha=0.1, pos=pos, arrows=False)
+        pos = nx.layout.spring_layout(graph, k=spread/math.sqrt(len(graph.nodes())))
+        _ = nx.draw_networkx_edges(graph, ax=ax, pos=pos,
+                                   width=line_width, alpha=line_alpha, arrows=False)
 
         if node_weights is None:
             if draw_nodes is True:
-                _ = nx.draw_networkx_nodes(graph, ax=ax, alpha=0.25, pos=pos, linewidths=0.5)
-            _ = nx.draw_networkx_labels(graph, pos, ax=ax, font_size=12,
+                _ = nx.draw_networkx_nodes(graph, ax=ax, pos=pos,
+                                           alpha=node_alpha, linewidths=0.5,
+                                           node_size=base_node_size)
+            _ = nx.draw_networkx_labels(graph, pos, ax=ax, font_size=base_font_size,
                                         font_color='black', font_family='sans-serif')
         else:
             max_node_weight = max(node_weights.values())
             if draw_nodes is True:
-                node_sizes = [600 * pow(node_weights[node]/max_node_weight, 0.75)
+                node_sizes = [base_node_size * pow(node_weights[node]/max_node_weight, 0.75)
                               for node in graph.nodes()]
                 _ = nx.draw_networkx_nodes(graph, ax=ax, pos=pos,
                                            node_size=node_sizes,
-                                           alpha=0.25, linewidths=0.5)
+                                           alpha=node_alpha, linewidths=0.5)
             for node, weight in node_weights.items():
                 _ = nx.draw_networkx_labels(graph, pos, labels={node: node}, ax=ax,
                                             font_color='black', font_family='sans-serif',
-                                            font_size=18 * pow(weight/max_node_weight, 0.15))
+                                            font_size=base_font_size * pow(weight/max_node_weight, 0.15))
 
         ax.set_frame_on(False)
         ax.set_xticklabels(['' for _ in range(len(ax.get_xticklabels()))])

--- a/textacy/viz/network.py
+++ b/textacy/viz/network.py
@@ -1,0 +1,80 @@
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import math
+
+import matplotlib.pyplot as plt
+import networkx as nx
+
+
+RC_PARAMS = {'axes.axisbelow': True,
+             'axes.edgecolor': '.8',
+             'axes.facecolor': 'white',
+             'axes.grid': False,
+             'axes.labelcolor': '.15',
+             'axes.linewidth': 1.0,
+             'figure.facecolor': 'white',
+             'font.family': ['sans-serif'],
+             'font.sans-serif': ['Arial', 'Liberation Sans', 'sans-serif'],
+             'grid.color': '.8', 'grid.linestyle': '-',
+             'image.cmap': 'Greys',
+             'legend.frameon': False,
+             'legend.numpoints': 1, 'legend.scatterpoints': 1,
+             'lines.solid_capstyle': 'round',
+             'text.color': '.15',
+             'xtick.color': '.15', 'xtick.direction': 'out',
+             'xtick.major.size': 0.0, 'xtick.minor.size': 0.0,
+             'ytick.color': '.15', 'ytick.direction': 'out',
+             'ytick.major.size': 0.0, 'ytick.minor.size': 0.0}
+
+
+def draw_semantic_network(graph, node_weights=None, draw_nodes=False,
+                          save=False):
+    """
+    Draw a semantic network with nodes representing either terms or sentences,
+    edges representing coocurrence or similarity, and positions given by a force-
+    directed layout.
+
+    Args:
+        graph (:class:`networkx.Graph <networkx.Graph>`):
+        node_weights (dict): mapping of node: weight, used to size node labels
+            (and, optionally, node circles) according to their weight
+        draw_nodes (bool): if True, circles are drawn under the node labels
+        save (str): give the full /path/to/fname on disk to save figure (optional)
+
+    Returns:
+        ``matplotlib.axes.Axes.axis``: axis on which network plot is drawn
+    """
+    with plt.rc_context(RC_PARAMS):
+        fig, ax = plt.subplots(figsize=(12, 12))
+
+        pos = nx.layout.spring_layout(graph, k=2.5/math.sqrt(len(graph.nodes())))
+        _ = nx.draw_networkx_edges(graph, ax=ax, alpha=0.1, pos=pos, arrows=False)
+
+        if node_weights is None:
+            if draw_nodes is True:
+                _ = nx.draw_networkx_nodes(graph, ax=ax, alpha=0.25, pos=pos, linewidths=0.5)
+            _ = nx.draw_networkx_labels(graph, pos, ax=ax, font_size=12,
+                                        font_color='black', font_family='sans-serif')
+        else:
+            max_node_weight = max(node_weights.values())
+            if draw_nodes is True:
+                node_sizes = [600 * pow(node_weights[node]/max_node_weight, 0.75)
+                              for node in graph.nodes()]
+                _ = nx.draw_networkx_nodes(graph, ax=ax, pos=pos,
+                                           node_size=node_sizes,
+                                           alpha=0.25, linewidths=0.5)
+            for node, weight in node_weights.items():
+                _ = nx.draw_networkx_labels(graph, pos, labels={node: node}, ax=ax,
+                                            font_color='black', font_family='sans-serif',
+                                            font_size=18 * pow(weight/max_node_weight, 0.15))
+
+        ax.set_frame_on(False)
+        ax.set_xticklabels(['' for _ in range(len(ax.get_xticklabels()))])
+        ax.set_yticklabels(['' for _ in range(len(ax.get_yticklabels()))])
+
+    if save:
+        fig.savefig(save, bbox_inches='tight', dpi=100)
+
+    return ax

--- a/textacy/viz/termite.py
+++ b/textacy/viz/termite.py
@@ -1,0 +1,102 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+RC_PARAMS = {'axes.axisbelow': True,
+             'axes.edgecolor': '.8',
+             'axes.facecolor': 'white',
+             'axes.grid': True,
+             'axes.labelcolor': '.15',
+             'axes.linewidth': 1.0,
+             'figure.facecolor': 'white',
+             'font.family': ['sans-serif'],
+             'font.sans-serif': ['Arial', 'Liberation Sans', 'sans-serif'],
+             'grid.color': '.8', 'grid.linestyle': '-',
+             'image.cmap': 'Greys',
+             'legend.frameon': False,
+             'legend.numpoints': 1, 'legend.scatterpoints': 1,
+             'lines.solid_capstyle': 'round',
+             'text.color': '.15',
+             'xtick.color': '.15', 'xtick.direction': 'out',
+             'xtick.major.size': 0.0, 'xtick.minor.size': 0.0,
+             'ytick.color': '.15', 'ytick.direction': 'out',
+             'ytick.major.size': 0.0, 'ytick.minor.size': 0.0}
+
+COLOR_PAIRS = (((0.65098041296005249, 0.80784314870834351, 0.89019608497619629),
+                (0.12572087695201239, 0.47323337360924367, 0.707327968232772)),
+               ((0.68899655751153521, 0.8681737867056154, 0.54376011946622071),
+                (0.21171857311445125, 0.63326415104024547, 0.1812226118410335)),
+               ((0.98320646005518297, 0.5980161709820524, 0.59423301088459368),
+                (0.89059593116535862, 0.10449827132271793, 0.11108035462744099)),
+               ((0.99175701702342312, 0.74648213716698619, 0.43401768935077328),
+                (0.99990772780250103, 0.50099192647372981, 0.0051211073118098693)),
+               ((0.78329874347238004, 0.68724338552531095, 0.8336793640080622),
+                (0.42485198495434734, 0.2511495584950722, 0.60386007743723258)),
+               ((0.99760092286502611, 0.99489427150464516, 0.5965244373854468),
+                (0.69411766529083252, 0.3490196168422699, 0.15686275064945221)))
+
+
+def termite_plot(values_mat, col_labels, row_labels, highlight_cols=None):
+    """
+    Args:
+        values_mat (``np.ndarray``-like)
+        col_labels (seq(str))
+        row_labels(seq(str))
+        highlight_cols (int or seq(int), optional)
+
+    Returns:
+        ``matplotlib.axis``
+    """
+    n_rows = len(row_labels)
+    n_cols = len(col_labels)
+    max_val = np.max(values_mat)
+    highlight_colors = {hc: COLOR_PAIRS[i]
+                        for i, hc in enumerate(highlight_cols)}
+
+    with plt.rc_context(RC_PARAMS):
+        _, ax = plt.subplots(figsize=(pow(n_cols, 0.8), pow(n_rows, 0.66)))
+
+        _ = ax.set_yticks(range(n_rows))
+        yticklabels = ax.set_yticklabels(row_labels,
+                                         fontsize=14, color='gray')
+        if highlight_cols is not None:
+            for i, ticklabel in enumerate(yticklabels):
+                max_tick_val = max(values_mat[i, hc] for hc in highlight_cols)
+                for hc in highlight_cols:
+                    if max_tick_val > 0 and values_mat[i, hc] == max_tick_val:
+                        ticklabel.set_color(highlight_colors[hc][1])
+
+        ax.get_xaxis().set_ticks_position('top')
+        _ = ax.set_xticks(range(n_cols))
+        xticklabels = ax.set_xticklabels(col_labels,
+                                         fontsize=14, color='gray',
+                                         rotation=30, ha='left')
+        if highlight_cols is not None:
+            gridlines = ax.get_xgridlines()
+            for i, ticklabel in enumerate(xticklabels):
+                if i in highlight_cols:
+                    ticklabel.set_color(highlight_colors[i][1])
+                    gridlines[i].set_color(highlight_colors[i][0])
+                    gridlines[i].set_alpha(0.5)
+
+        for col_ind in range(n_cols):
+            if highlight_cols is not None and col_ind in highlight_cols:
+                ax.scatter([col_ind for _ in range(n_rows)],
+                           [i for i in range(n_rows)],
+                           s=600*(values_mat[:, col_ind] / max_val),
+                           alpha=0.5, linewidth=1,
+                           color=highlight_colors[col_ind][0],
+                           edgecolor=highlight_colors[col_ind][1])
+            else:
+                ax.scatter([col_ind for _ in range(n_rows)],
+                           [i for i in range(n_rows)],
+                           s=600*(values_mat[:, col_ind] / max_val),
+                           alpha=0.5, linewidth=1,
+                           color='lightgray', edgecolor='gray')
+
+            _ = ax.set_xlim(left=-1, right=n_cols)
+            _ = ax.set_ylim(bottom=-1, top=n_rows)
+
+    return ax

--- a/textacy/viz/termite.py
+++ b/textacy/viz/termite.py
@@ -40,15 +40,35 @@ COLOR_PAIRS = (((0.65098041296005249, 0.80784314870834351, 0.89019608497619629),
 
 def termite_plot(values_mat, col_labels, row_labels, highlight_cols=None):
     """
+    Make a "termite" plot, typically used for assessing topic models with a tabular
+    layout that promotes comparison of terms both within and across topics.
+
     Args:
-        values_mat (``np.ndarray``-like)
-        col_labels (seq(str))
-        row_labels(seq(str))
-        highlight_cols (int or seq(int), optional)
+        values_mat (``np.ndarray`` or matrix): matrix of values with shape
+            (# row labels, # col labels) used to size the dots on the grid
+        col_labels (seq(str)): labels used to identify x-axis ticks on the grid
+        row_labels(seq(str)): labels used to identify y-axis ticks on the grid
+        highlight_cols (int or seq(int), optional): indices for up to 6 columns
+            to visually highlight in the plot with contrasting colors
 
     Returns:
-        ``matplotlib.axis``
+        ``matplotlib.axes.Axes.axis``: axis on which termite plot is plotted
+
+    Raises:
+        ValueError: if more than 6 columns are selected for highlighting
+
+    References:
+        .. Chuang, Jason, Christopher D. Manning, and Jeffrey Heer. "Termite:
+            Visualization techniques for assessing textual topic models."
+            Proceedings of the International Working Conference on Advanced
+            Visual Interfaces. ACM, 2012.
     """
+    if highlight_cols is not None:
+        if isinstance(highlight_cols, int):
+            highlight_cols = (highlight_cols,)
+        elif len(highlight_cols) > 6:
+            raise ValueError('no more than 6 columns may be highlighted at once')
+
     n_rows = len(row_labels)
     n_cols = len(col_labels)
     max_val = np.max(values_mat)

--- a/textacy/viz/termite.py
+++ b/textacy/viz/termite.py
@@ -38,7 +38,8 @@ COLOR_PAIRS = (((0.65098041296005249, 0.80784314870834351, 0.89019608497619629),
                 (0.69411766529083252, 0.3490196168422699, 0.15686275064945221)))
 
 
-def termite_plot(values_mat, col_labels, row_labels, highlight_cols=None):
+def termite_plot(values_mat, col_labels, row_labels,
+                 highlight_cols=None, save=False):
     """
     Make a "termite" plot, typically used for assessing topic models with a tabular
     layout that promotes comparison of terms both within and across topics.
@@ -50,6 +51,7 @@ def termite_plot(values_mat, col_labels, row_labels, highlight_cols=None):
         row_labels(seq(str)): labels used to identify y-axis ticks on the grid
         highlight_cols (int or seq(int), optional): indices for up to 6 columns
             to visually highlight in the plot with contrasting colors
+        save (str, optional): give the full /path/to/fname on disk to save figure
 
     Returns:
         ``matplotlib.axes.Axes.axis``: axis on which termite plot is plotted
@@ -62,6 +64,8 @@ def termite_plot(values_mat, col_labels, row_labels, highlight_cols=None):
             Visualization techniques for assessing textual topic models."
             Proceedings of the International Working Conference on Advanced
             Visual Interfaces. ACM, 2012.
+
+    .. seealso:: :func:`TopicModel.termite_plot <textacy.tm.TopicModel.termite_plot>`
     """
     if highlight_cols is not None:
         if isinstance(highlight_cols, int):
@@ -76,7 +80,7 @@ def termite_plot(values_mat, col_labels, row_labels, highlight_cols=None):
                         for i, hc in enumerate(highlight_cols)}
 
     with plt.rc_context(RC_PARAMS):
-        _, ax = plt.subplots(figsize=(pow(n_cols, 0.8), pow(n_rows, 0.66)))
+        fig, ax = plt.subplots(figsize=(pow(n_cols, 0.8), pow(n_rows, 0.66)))
 
         _ = ax.set_yticks(range(n_rows))
         yticklabels = ax.set_yticklabels(row_labels,
@@ -118,5 +122,8 @@ def termite_plot(values_mat, col_labels, row_labels, highlight_cols=None):
 
             _ = ax.set_xlim(left=-1, right=n_cols)
             _ = ax.set_ylim(bottom=-1, top=n_rows)
+
+    if save:
+        fig.savefig(save, bbox_inches='tight', dpi=100)
 
     return ax

--- a/textacy/viz/termite.py
+++ b/textacy/viz/termite.py
@@ -38,8 +38,8 @@ COLOR_PAIRS = (((0.65098041296005249, 0.80784314870834351, 0.89019608497619629),
                 (0.69411766529083252, 0.3490196168422699, 0.15686275064945221)))
 
 
-def termite_plot(values_mat, col_labels, row_labels,
-                 highlight_cols=None, save=False):
+def draw_termite_plot(values_mat, col_labels, row_labels,
+                      highlight_cols=None, save=False):
     """
     Make a "termite" plot, typically used for assessing topic models with a tabular
     layout that promotes comparison of terms both within and across topics.
@@ -122,6 +122,8 @@ def termite_plot(values_mat, col_labels, row_labels,
 
             _ = ax.set_xlim(left=-1, right=n_cols)
             _ = ax.set_ylim(bottom=-1, top=n_rows)
+
+            ax.invert_yaxis()  # otherwise, values/labels go from bottom to top
 
     if save:
         fig.savefig(save, bbox_inches='tight', dpi=100)


### PR DESCRIPTION
Changes:

- Added a `viz` subpackage, with two modules:
    - `termite.py` for drawing "termite" plots, commonly used to evaluate and interpret topic models
    - `network.py` for drawing semantic networks, such as the output of `representations.network`

There are currently no tests, which I think I'm okay with (for now). I'm sort of hustling on this.

@danvalente: What say you?