### PR TITLE
consistent corpora readers for reddit and wikipedia

### DIFF
--- a/tests/test_corpora_bernie_and_hillary.py
+++ b/tests/test_corpora_bernie_and_hillary.py
@@ -7,7 +7,7 @@ import unittest
 from textacy.corpora import bernie_and_hillary
 
 
-class CorporaTestCase(unittest.TestCase):
+class BernieAndHillaryTestCase(unittest.TestCase):
 
     def setUp(self):
         self.tempdir = tempfile.mkdtemp(

--- a/tests/test_corpora_reddit_reader.py
+++ b/tests/test_corpora_reddit_reader.py
@@ -1,63 +1,64 @@
-# from __future__ import absolute_import, unicode_literals
-#
-# import json
-# import os
-# import tempfile
-# import unittest
-#
-# from textacy.compat import bzip_open, str
-# from textacy.corpora import RedditReader
-#
-# REDDIT_TEXT = r"""
-# {"author_flair_css_class": None, "created_utc": "1420070400", "controversiality": 0, "parent_id": "t3_2qyr1a", "score": 14, "author": "YoungModern", "subreddit_id": "t5_2r0gj", "gilded": 0, "distinguished": None, "id": "cnas8zv", "link_id": "t3_2qyr1a", "name": "t1_cnas8zv", "author_flair_text": None, "downs": 0, "subreddit": "exmormon", "ups": 14, "edited": False, "retrieved_on": 1425124282, "body": "Most of us have some family members like this. *Most* of my family is like this. ", "score_hidden": False, "archived": False}
-# {"author_flair_css_class": "on", "created_utc": "1420070400", "parent_id": "t1_cnas2b6", "downs": 0, "score": 3, "author_flair_text": "Ontario", "subreddit_id": "t5_2s4gt", "gilded": 0, "distinguished": None, "id": "cnas8zw", "link_id": "t3_2qv6c6", "author": "RedCoatsForever", "controversiality": 0, "retrieved_on": 1425124282, "archived": False, "subreddit": "CanadaPolitics", "edited": False, "ups": 3, "body": "But Mill"s career was way better. Bentham is like, the Joseph Smith to Mill"s Brigham Young.", "score_hidden": False, "name": "t1_cnas8zw"}
-# {"author_flair_css_class": None, "created_utc": "1420070400", "parent_id": "t3_2qxefp", "author_flair_text": None, "score": 1, "subreddit_id": "t5_2s7tt", "gilded": 0, "distinguished": None, "id": "cnas8zx", "link_id": "t3_2qxefp", "author": "vhisic", "name": "t1_cnas8zx", "retrieved_on": 1425124282, "downs": 0, "subreddit": "AdviceAnimals", "controversiality": 0, "edited": False, "ups": 1, "body": "Mine uses a strait razor, and as much as i love the clippers i love the razor so much more. Then he follows it up with a warm towel. \nI think i might go get a hair cut this week.", "score_hidden": False, "archived": False}
-# """
+from __future__ import absolute_import, unicode_literals
 
-# TODO: Make this work. There's some insane bullshit happening with json and bzip
-# as related to unicode vs bytes, and this is different in Py 2 vs Py 3. For now,
-# to hell with this testcase.
+import json
+import os
+import tempfile
+import unittest
+
+from textacy.compat import bzip_open, str
+from textacy.corpora import RedditReader
 
 
-# class RedditReaderTestCase(unittest.TestCase):
-#
-#     def setUp(self):
-#         self.tempdir = tempfile.mkdtemp(
-#             prefix='test_corpora', dir=os.path.dirname(os.path.abspath(__file__)))
-#         reddit_fname = os.path.join(self.tempdir, 'RC_test.bz2')
-#         with bzip_open(reddit_fname, mode='wt') as f:
-#             for line in REDDIT_TEXT.split('\n'):
-#                 if line:
-#                     f.write(json.dumps(line.strip()))
-#         self.redditreader = RedditReader(reddit_fname)
-#
-#     def test_texts(self):
-#         texts = list(self.redditreader.texts())
-#         for text in texts:
-#             self.assertIsInstance(text, str)
-#
-#     def test_texts_min_len(self):
-#         texts = list(self.redditreader.texts(min_len=100))
-#         self.assertEqual(len(texts), 1)
-#
-#     def test_texts_limit(self):
-#         texts = list(self.redditreader.texts(limit=1))
-#         self.assertEqual(len(texts), 1)
-#
-#     def test_comments(self):
-#         comments = list(self.redditreader.comments())
-#         for comment in comments:
-#             self.assertIsInstance(comment, dict)
-#
-#     def test_pages_min_len(self):
-#         comments = list(self.redditreader.comments(min_len=100))
-#         self.assertEqual(len(comments), 1)
-#
-#     def test_pages_limit(self):
-#         comments = list(self.redditreader.comments(limit=1))
-#         self.assertEqual(len(comments), 1)
-#
-#     def tearDown(self):
-#         for fname in os.listdir(self.tempdir):
-#             os.remove(os.path.join(self.tempdir, fname))
-#         os.rmdir(self.tempdir)
+REDDIT_COMMENTS = [
+    {"author_flair_css_class": None, "created_utc": "1420070400", "controversiality": 0, "parent_id": "t3_2qyr1a", "score": 14, "author": "YoungModern", "subreddit_id": "t5_2r0gj", "gilded": 0, "distinguished": None, "id": "cnas8zv", "link_id": "t3_2qyr1a", "name": "t1_cnas8zv", "author_flair_text": None, "downs": 0, "subreddit": "exmormon", "ups": 14, "edited": False, "retrieved_on": 1425124282, "body": "Most of us have some family members like this. *Most* of my family is like this. ", "score_hidden": False, "archived": False},
+    {"author_flair_css_class": "on", "created_utc": "1420070400", "parent_id": "t1_cnas2b6", "downs": 0, "score": 3, "author_flair_text": "Ontario", "subreddit_id": "t5_2s4gt", "gilded": 0, "distinguished": None, "id": "cnas8zw", "link_id": "t3_2qv6c6", "author": "RedCoatsForever", "controversiality": 0, "retrieved_on": 1425124282, "archived": False, "subreddit": "CanadaPolitics", "edited": False, "ups": 3, "body": "But Mill's career was way better. Bentham is like, the Joseph Smith to Mill's Brigham Young.", "score_hidden": False, "name": "t1_cnas8zw"},
+    {"author_flair_css_class": None, "created_utc": "1420070400", "parent_id": "t3_2qxefp", "author_flair_text": None, "score": 1, "subreddit_id": "t5_2s7tt", "gilded": 0, "distinguished": None, "id": "cnas8zx", "link_id": "t3_2qxefp", "author": "vhisic", "name": "t1_cnas8zx", "retrieved_on": 1425124282, "downs": 0, "subreddit": "AdviceAnimals", "controversiality": 0, "edited": False, "ups": 1, "body": "Mine uses a strait razor, and as much as i love the clippers i love the razor so much more. Then he follows it up with a warm towel. \nI think i might go get a hair cut this week.", "score_hidden": False, "archived": False},
+]
+
+
+class RedditReaderTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp(
+            prefix='test_corpora', dir=os.path.dirname(os.path.abspath(__file__)))
+        reddit_fname = os.path.join(self.tempdir, 'RC_test.bz2')
+        try:
+            with bzip_open(reddit_fname, mode='wt') as f:
+                for comment in REDDIT_COMMENTS:
+                    f.write(json.dumps(comment, ensure_ascii=False) + '\n')
+        except ValueError:  # Python 2 fail
+            with bzip_open(reddit_fname, mode='wb') as f:
+                for comment in REDDIT_COMMENTS:
+                    f.write(json.dumps(comment, ensure_ascii=True) + '\n')
+        self.redditreader = RedditReader(reddit_fname)
+
+    def test_texts(self):
+        texts = list(self.redditreader.texts())
+        for text in texts:
+            self.assertIsInstance(text, str)
+
+    def test_texts_min_len(self):
+        texts = list(self.redditreader.texts(min_len=100))
+        self.assertEqual(len(texts), 1)
+
+    def test_texts_limit(self):
+        texts = list(self.redditreader.texts(limit=1))
+        self.assertEqual(len(texts), 1)
+
+    def test_comments(self):
+        comments = list(self.redditreader.comments())
+        for comment in comments:
+            self.assertIsInstance(comment, dict)
+
+    def test_pages_min_len(self):
+        comments = list(self.redditreader.comments(min_len=100))
+        self.assertEqual(len(comments), 1)
+
+    def test_pages_limit(self):
+        comments = list(self.redditreader.comments(limit=1))
+        self.assertEqual(len(comments), 1)
+
+    def tearDown(self):
+        for fname in os.listdir(self.tempdir):
+            os.remove(os.path.join(self.tempdir, fname))
+        os.rmdir(self.tempdir)

--- a/tests/test_corpora_reddit_reader.py
+++ b/tests/test_corpora_reddit_reader.py
@@ -1,0 +1,63 @@
+# from __future__ import absolute_import, unicode_literals
+#
+# import json
+# import os
+# import tempfile
+# import unittest
+#
+# from textacy.compat import bzip_open, str
+# from textacy.corpora import RedditReader
+#
+# REDDIT_TEXT = r"""
+# {"author_flair_css_class": None, "created_utc": "1420070400", "controversiality": 0, "parent_id": "t3_2qyr1a", "score": 14, "author": "YoungModern", "subreddit_id": "t5_2r0gj", "gilded": 0, "distinguished": None, "id": "cnas8zv", "link_id": "t3_2qyr1a", "name": "t1_cnas8zv", "author_flair_text": None, "downs": 0, "subreddit": "exmormon", "ups": 14, "edited": False, "retrieved_on": 1425124282, "body": "Most of us have some family members like this. *Most* of my family is like this. ", "score_hidden": False, "archived": False}
+# {"author_flair_css_class": "on", "created_utc": "1420070400", "parent_id": "t1_cnas2b6", "downs": 0, "score": 3, "author_flair_text": "Ontario", "subreddit_id": "t5_2s4gt", "gilded": 0, "distinguished": None, "id": "cnas8zw", "link_id": "t3_2qv6c6", "author": "RedCoatsForever", "controversiality": 0, "retrieved_on": 1425124282, "archived": False, "subreddit": "CanadaPolitics", "edited": False, "ups": 3, "body": "But Mill"s career was way better. Bentham is like, the Joseph Smith to Mill"s Brigham Young.", "score_hidden": False, "name": "t1_cnas8zw"}
+# {"author_flair_css_class": None, "created_utc": "1420070400", "parent_id": "t3_2qxefp", "author_flair_text": None, "score": 1, "subreddit_id": "t5_2s7tt", "gilded": 0, "distinguished": None, "id": "cnas8zx", "link_id": "t3_2qxefp", "author": "vhisic", "name": "t1_cnas8zx", "retrieved_on": 1425124282, "downs": 0, "subreddit": "AdviceAnimals", "controversiality": 0, "edited": False, "ups": 1, "body": "Mine uses a strait razor, and as much as i love the clippers i love the razor so much more. Then he follows it up with a warm towel. \nI think i might go get a hair cut this week.", "score_hidden": False, "archived": False}
+# """
+
+# TODO: Make this work. There's some insane bullshit happening with json and bzip
+# as related to unicode vs bytes, and this is different in Py 2 vs Py 3. For now,
+# to hell with this testcase.
+
+
+# class RedditReaderTestCase(unittest.TestCase):
+#
+#     def setUp(self):
+#         self.tempdir = tempfile.mkdtemp(
+#             prefix='test_corpora', dir=os.path.dirname(os.path.abspath(__file__)))
+#         reddit_fname = os.path.join(self.tempdir, 'RC_test.bz2')
+#         with bzip_open(reddit_fname, mode='wt') as f:
+#             for line in REDDIT_TEXT.split('\n'):
+#                 if line:
+#                     f.write(json.dumps(line.strip()))
+#         self.redditreader = RedditReader(reddit_fname)
+#
+#     def test_texts(self):
+#         texts = list(self.redditreader.texts())
+#         for text in texts:
+#             self.assertIsInstance(text, str)
+#
+#     def test_texts_min_len(self):
+#         texts = list(self.redditreader.texts(min_len=100))
+#         self.assertEqual(len(texts), 1)
+#
+#     def test_texts_limit(self):
+#         texts = list(self.redditreader.texts(limit=1))
+#         self.assertEqual(len(texts), 1)
+#
+#     def test_comments(self):
+#         comments = list(self.redditreader.comments())
+#         for comment in comments:
+#             self.assertIsInstance(comment, dict)
+#
+#     def test_pages_min_len(self):
+#         comments = list(self.redditreader.comments(min_len=100))
+#         self.assertEqual(len(comments), 1)
+#
+#     def test_pages_limit(self):
+#         comments = list(self.redditreader.comments(limit=1))
+#         self.assertEqual(len(comments), 1)
+#
+#     def tearDown(self):
+#         for fname in os.listdir(self.tempdir):
+#             os.remove(os.path.join(self.tempdir, fname))
+#         os.rmdir(self.tempdir)

--- a/tests/test_corpora_wiki_reader.py
+++ b/tests/test_corpora_wiki_reader.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+import os
+import tempfile
+import unittest
+
+from textacy.compat import bzip_open, str
+from textacy.corpora import WikiReader
+
+WIKITEXT = r"""
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.10/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.10/ http://www.mediawiki.org/xml/export-0.10.xsd" version="0.10" xml:lang="en">
+  <page>
+    <title>AccessibleComputing</title>
+    <ns>0</ns>
+    <id>10</id>
+    <redirect title="Computer accessibility" />
+    <revision>
+      <id>631144794</id>
+      <parentid>381202555</parentid>
+      <timestamp>2014-10-26T04:50:23Z</timestamp>
+      <contributor>
+        <username>Paine Ellsworth</username>
+        <id>9092818</id>
+      </contributor>
+      <comment>add [[WP:RCAT|rcat]]s</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve">#REDIRECT [[Computer accessibility]]
+
+{{Redr|move|from CamelCase|up}}</text>
+      <sha1>4ro7vvppa5kmm0o1egfjztzcwd0vabw</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>AmoeboidTaxa</title>
+    <ns>0</ns>
+    <id>24</id>
+    <redirect title="Amoeba" />
+    <revision>
+      <id>627604809</id>
+      <parentid>625443465</parentid>
+      <timestamp>2014-09-29T22:26:03Z</timestamp>
+      <contributor>
+        <username>Invadibot</username>
+        <id>15934865</id>
+      </contributor>
+      <minor />
+      <comment>Bot: Fixing double redirect to [[Amoeba]]</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve">#REDIRECT [[Amoeba]] {{R from CamelCase}}</text>
+      <sha1>afkde9noo6ive9c3gr5pq9sqlqf6w64</sha1>
+    </revision>
+  </page>
+  <page>
+    <title>Autism</title>
+    <ns>0</ns>
+    <id>25</id>
+    <revision>
+      <id>692971972</id>
+      <parentid>691895142</parentid>
+      <timestamp>2015-11-29T16:00:39Z</timestamp>
+      <contributor>
+        <username>Iridescent</username>
+        <id>937705</id>
+      </contributor>
+      <minor />
+      <comment>/* Society and culture */[[WP:AWB/T|Typo fixing]], [[WP:AWB/T|typo(s) fixed]]: a influence → an influence, more more → more using [[Project:AWB|AWB]]</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve">{{Hatnote|This article is about the classic autistic disorder; some writers use the word ''autism'' when referring to the range of disorders on the [[autism spectrum]] or to the various [[pervasive developmental disorder]]s.&lt;ref name=Caronna/&gt;}}
+{{pp-semi-indef}}
+{{pp-move-indef}}
+{{bots|deny=Monkbot}} &lt;!-- keep Monkbot  from visiting this page --&gt;
+{{Use dmy dates|date=June 2015}}
+&lt;!-- NOTES:
+1) Please follow the Wikipedia style guidelines for editing medical articles [[WP:MEDMOS]], and medical referencing standards at [[WP:MEDRS]].
+2) Use &lt;ref&gt; for explicitly cited references.
+3) Reference anything you put here with notable references, as this subject tends to attract a lot of controversy.--&gt;
+{{Infobox disease
+| Name = Autism
+| Image = Autism-stacking-cans 2nd edit.jpg
+| Alt = Young red-haired boy facing away from camera, stacking a seventh can atop a column of six food cans on the kitchen floor. An open pantry contains many more cans.
+| Caption = Repetitively stacking or lining up objects is associated with autism.
+| field = [[Psychiatry]]
+| DiseasesDB = 1142
+| ICD10 = {{ICD10|F|84|0|f|80}}
+| ICD9 = {{ICD9|299.00}}
+| OMIM = 209850
+| MedlinePlus = 001526
+| eMedicineSubj = med
+| eMedicineTopic = 3202
+| eMedicine_mult = {{eMedicine2|ped|180}}
+| MeshID = D001321
+| GeneReviewsNBK = NBK1442
+| GeneReviewsName = Autism overview
+}}
+&lt;!-- Definition and symptoms --&gt;
+'''Autism''' is a [[neurodevelopmental disorder]] characterized by impaired [[Interpersonal relationship|social interaction]], [[language acquisition|verbal]] and [[non-verbal communication]], and restricted and repetitive behavior. Parents usually notice signs in the first two years of their child's life.&lt;ref name=CCD/&gt; These signs often develop gradually, though some children with autism reach their [[developmental milestones]] at a normal pace and then [[Regressive autism|regress]].&lt;ref name=Stefanatos/&gt; The [[Diagnostic and Statistical Manual of Mental Disorders|diagnostic criteria]] require that symptoms become apparent in early childhood, typically before age three.&lt;ref name=DSM5&gt;{{vcite book | title = Diagnostic and Statistical Manual of Mental Disorders, Fifth Edition | chapter = Autism Spectrum Disorder, 299.00 (F84.0) | editor = American Psychiatric Association | year = 2013 | publisher = American Psychiatric Publishing | pagex = 50–59}}&lt;/ref&gt;
+
+&lt;!-- Causes and diagnosis --&gt;
+While autism is highly heritable, researchers suspect both environmental and genetic factors as causes.&lt;ref&gt;{{cite journal |author=Chaste P, Leboyer M |title=Autism risk factors: genes, environment, and gene-environment interactions |journal=Dialogues in Clinical Neuroscience |volume=14  |pages=281–92 |year=2012 |pmid=23226953 |pmc=3513682 }}&lt;/ref&gt; In rare cases, autism is strongly associated with [[Teratology|agents that cause birth defects]].&lt;ref name=Arndt/&gt; [[Controversies in autism|Controversies]] surround other proposed environmental [[Causes of autism|causes]];&lt;ref name=Rutter/&gt; for example, the [[MMR vaccine controversy|vaccine hypotheses]] have been disproven. Autism affects information processing in the [[Human brain|brain]] by altering how [[nerve cell]]s and their [[synapse]]s connect and organize; how this occurs is not well understood.&lt;ref name=&quot;Levy&quot; /&gt; It is one of three recognized disorders in the [[autism spectrum]] (ASDs), the other two being [[Asperger syndrome]], which lacks delays in cognitive development and language, and [[PDD-NOS|pervasive developmental disorder, not otherwise specified]] (commonly abbreviated as PDD-NOS), which is diagnosed when the full set of criteria for autism or Asperger syndrome are not met.&lt;ref name=&quot;Johnson&quot; /&gt;
+
+&lt;!-- Treatment --&gt;
+Early speech or [[Early intensive behavioral intervention|behavioral interventions]] can help children with autism gain self-care, social, and communication skills.&lt;ref name=CCD/&gt; Although there is no known cure,&lt;ref name=CCD/&gt; there have been reported cases of children who recovered.&lt;ref name=Helt/&gt; Not many children with autism live independently after reaching adulthood, though some become successful.&lt;ref name=&quot;Howlin&quot;&gt;{{cite journal | vauthors = Howlin P, Goode S, Hutton J, Rutter M | title = Adult outcome for children with autism | journal = J Child Psychol Psychiatry | volume = 45 | issue = 2 | pages = 212–29 | year = 2004 | doi = 10.1111/j.1469-7610.2004.00215.x | pmid = 14982237}}&lt;/ref&gt; An [[Sociological and cultural aspects of autism|autistic culture]] has developed, with some individuals seeking a cure and others believing autism should be [[Autism rights movement|accepted as a difference and not treated as a disorder]].&lt;ref name=Silverman/&gt;
+
+&lt;!-- Epidemiology --&gt;
+Globally, autism is estimated to affect 21.7 million people as of 2013.&lt;ref name=&quot;Collab&quot;&gt;{{cite journal |author = Global Burden of Disease Study 2013 Collaborators |title=Global, regional, and national incidence, prevalence, and years lived with disability for 301 acute and chronic diseases and injuries in 188 countries, 1990–2013: a systematic analysis for the Global Burden of Disease Study 2013.|journal=Lancet|year = 2015|pmid=26063472 |doi=10.1016/S0140-6736(15)60692-4}}&lt;/ref&gt; As of 2010, the number of people affected is estimated at about 1–2 per 1,000 worldwide. It occurs four to five times more often in boys than girls. About 1.5% of children in the United States (one in 68) are diagnosed with ASD {{as of|2014|lc=y}}, a 30% increase from one in 88 in 2012.&lt;ref name=&quot;ASD Data and Statistics&quot;&gt;{{cite web |url = http://www.cdc.gov/ncbddd/autism/data.html |title = ASD Data and Statistics |website = CDC.gov |accessdate= 5 April 2014 |archiveurl = https://web.archive.org/web/20140418153648/http://www.cdc.gov/ncbddd/autism/data.html |archivedate = 18 April 2014 }}&lt;/ref&gt;&lt;ref name=&quot;MMWR2012&quot;&gt;{{cite journal | vauthors =  | title = Prevalence of autism spectrum disorders&amp;nbsp;— autism and developmental disabilities monitoring network, 14 sites, United States, 2008 | journal = MMWR Surveill Summ | volume = 61 | issue = 3 | pages = 1–19 | year = 2012 | pmid = 22456193 | url = http://www.cdc.gov/mmwr/preview/mmwrhtml/ss6103a1.htm | archivedate = 25 March 2014 | archiveurl = https://web.archive.org/web/20140325235639/http://www.cdc.gov/mmwr/preview/mmwrhtml/ss6103a1.htm }}&lt;/ref&gt;&lt;ref name=&quot;NHSR65&quot;&gt;{{cite journal | vauthors = Blumberg SJ, Bramlett MD, Kogan MD, Schieve LA, Jones JR, Lu MC | title = Changes in prevalence of parent-reported autism spectrum disorder in school-aged U.S. children: 2007 to 2011–2012 | journal = Natl Health Stat Report | volume = | issue = 65 | pages = 1–11 | year = 2013 | pmid = 24988818 | url = http://www.cdc.gov/nchs/data/nhsr/nhsr065.pdf | archiveurl = http://www.webcitation.org/6JoG0uE7r|archivedate=21 September 2013 }}&lt;/ref&gt; The rate of autism among adults aged 18 years and over in the United Kingdom is 1.1%.&lt;ref name=NHSEstimating/&gt; The number of people diagnosed has been increasing dramatically since the 1980s, partly due to changes in diagnostic practice and government-subsidized financial incentives for named diagnoses;&lt;ref name=&quot;NHSR65&quot;/&gt; the question of whether actual rates have increased is unresolved.&lt;ref name=Newschaffer/&gt;
+
+==Characteristics==
+Autism is a highly variable [[neurodevelopmental disorder]]&lt;ref name=Geschwind/&gt; that first appears during infancy or childhood, and generally follows a steady course without [[Remission (medicine)|remission]].&lt;ref name=ICD-10-F84.0/&gt; People with autism may be severely impaired in some respects but normal, or even superior, in others.&lt;ref&gt;{{vcite book|title = Biopsychology|author= Pinel JPG|publisher = Pearson|year = 2011|isbn = 978-0-205-03099-6|location = Boston, Massachusetts|page = 235}}&lt;/ref&gt; Overt symptoms gradually begin after the age of six months, become established by age two or three years,&lt;ref&gt;{{cite journal | vauthors = Rogers SJ | title = What are infant siblings teaching us about autism in infancy? | journal = Autism Res | volume = 2 | issue = 3 | pages = 125–37 | year = 2009 | pmid = 19582867 | pmc = 2791538 | doi = 10.1002/aur.81  }}&lt;/ref&gt; and tend to continue through adulthood, although often in more muted form.&lt;ref name=Rapin/&gt; It is distinguished not by a single symptom, but by a characteristic triad of symptoms: impairments in social interaction; impairments in communication; and restricted interests and repetitive behavior. Other aspects, such as atypical eating, are also common but are not essential for diagnosis.&lt;ref name=Filipek/&gt; Autism's individual symptoms occur in the general population and appear not to associate highly, without a sharp line separating pathologically severe from common traits.&lt;ref name=London/&gt;
+
+==References==
+{{reflist|32em}}
+
+==Further reading==
+*{{vcite book|author=Sicile-Kira, C|title=Autism spectrum disorder: the complete guide to understanding autism|date=2014|publisher=Perigee|location=New York, New York|isbn=978-0-399-16663-1|edition=Revised Perigee trade paperback}}
+*{{vcite book|author=Waltz, M|title=Autism: A Social and Medical History|date=22 March 2013|publisher=Palgrave Macmillan|isbn=978-0-230-52750-8|edition=1st}}
+*{{vcite book|author=[[Steve Silberman|Silberman, S]]|title=NeuroTribes: The Legacy of Autism and How to Think Smarter About People Who Think Differently|date=2015|publisher=[[Allen &amp; Unwin]]|location=Crows Nest, New South Wales|isbn=978-1-760-11363-6|edition=1st}}
+
+==External links==
+{{Sister project links|d=Q38404|s=no|n=Category:Autism|wikt=autism|species=no|voy=no|m=no|mw=no|q=no|v=no}}
+* {{dmoz|Health/Mental_Health/Disorders/Neurodevelopmental/Autism_Spectrum}}
+
+{{featured article}}
+{{Pervasive developmental disorders}}
+{{Mental and behavioral disorders|selected = childhood}}
+{{Autism resources}}
+{{Autism films}}
+{{Portal bar|Pervasive developmental disorders}}
+
+[[Category:Autism| ]]
+[[Category:Communication disorders]]
+[[Category:Mental and behavioural disorders]]
+[[Category:Neurological disorders]]
+[[Category:Neurological disorders in children]]
+[[Category:Pervasive developmental disorders]]
+[[Category:Psychiatric diagnosis]]</text>
+      <sha1>jrwedqcbxp53m5c4g7umfqmh2alo26n</sha1>
+    </revision>
+  </page>
+</mediawiki>
+""".encode('ascii', errors='ignore')  # ugh, Python 2 requires this
+
+
+class WikiReaderTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp(
+            prefix='test_corpora', dir=os.path.dirname(os.path.abspath(__file__)))
+        wiki_fname =os.path.join(self.tempdir, 'wikitext.xml.bz2')
+        with bzip_open(wiki_fname, mode='w') as f:
+            f.write(WIKITEXT)
+        self.wikireader = WikiReader(wiki_fname)
+
+    def test_texts(self):
+        texts = list(self.wikireader.texts())
+        for text in texts:
+            self.assertIsInstance(text, str)
+
+    def test_texts_min_len(self):
+        texts = list(self.wikireader.texts(min_len=300))
+        self.assertEqual(len(texts), 1)
+
+    def test_texts_limit(self):
+        texts = list(self.wikireader.texts(limit=1))
+        self.assertEqual(len(texts), 1)
+
+    def test_pages(self):
+        pages = list(self.wikireader.pages())
+        for page in pages:
+            self.assertIsInstance(page, dict)
+
+    def test_pages_min_len(self):
+        pages = list(self.wikireader.pages(min_len=300))
+        self.assertEqual(len(pages), 1)
+
+    def test_pages_limit(self):
+        pages = list(self.wikireader.pages(limit=1))
+        self.assertEqual(len(pages), 1)
+
+    def tearDown(self):
+        for fname in os.listdir(self.tempdir):
+            os.remove(os.path.join(self.tempdir, fname))
+        os.rmdir(self.tempdir)

--- a/textacy/corpora/__init__.py
+++ b/textacy/corpora/__init__.py
@@ -1,2 +1,3 @@
-from . import wikipedia
+from .wikipedia import WikiReader
+from .reddit_reader import RedditReader
 from .bernie_and_hillary import fetch_bernie_and_hillary

--- a/textacy/corpora/__init__.py
+++ b/textacy/corpora/__init__.py
@@ -1,3 +1,3 @@
-from .wikipedia import WikiReader
+from .wiki_reader import WikiReader
 from .reddit_reader import RedditReader
 from .bernie_and_hillary import fetch_bernie_and_hillary

--- a/textacy/corpora/reddit_reader.py
+++ b/textacy/corpora/reddit_reader.py
@@ -1,0 +1,85 @@
+"""
+"""
+import bz2
+import re
+
+import ujson
+
+from textacy.preprocess import normalize_whitespace
+
+
+REDDIT_LINK_RE = re.compile(r'\[([^]]+)\]\(https?://[^\)]+\)')
+
+
+class RedditReader(object):
+
+    def __init__(self, path):
+        self.path = path
+
+    def __iter__(self):
+        with bz2.BZ2File(self.path) as f:
+            for line in f:
+                yield ujson.loads(line)
+
+    def _clean_content(self, content):
+        # strip out link markup, e.g. [foo](http://foo.com)
+        content = REDDIT_LINK_RE.sub(r'\1', content)
+        # clean up basic HTML cruft
+        content = content.replace('&gt;', '>').replace('&lt;', '<')
+        # strip out text markup, e.g. * for bold text
+        content = content.replace('`', '').replace('*', '').replace('~', '')
+        # normalize whitespace
+        return normalize_whitespace(content)
+
+    def texts(self, min_len=0, limit=-1):
+        """
+        Iterate over the comments in a reddit comments file (RC_*.bz2),
+        yielding the plain text of a comment, one at a time.
+
+        Args:
+            min_len (int): minimum length in chars that a comment must have
+                for it to be returned; too-short comments are skipped (optional)
+            limit (int): maximum number of comments (passing `min_len`) to yield;
+                if -1, all comments in the db file are iterated over (optional)
+
+        Yields:
+            str: plain text for the next comment in the reddit comments file
+        """
+        n_comments = 0
+        for comment in self:
+            text = self._clean_content(comment['body'])
+            if len(text) < min_len:
+                continue
+
+            yield text
+
+            n_comments += 1
+            if n_comments == limit:
+                break
+
+    def comments(self, min_len=0, limit=-1):
+        """
+        Iterate over the comments in a reddit comments file (RC_*.bz2),
+        yielding one comment at a time, as a dict.
+
+        Args:
+            min_len (int): minimum length in chars that a page must have
+                for it to be returned; too-short pages are skipped
+            limit (int): maximum number of pages (passing ``min_len``) to yield;
+                if -1, all pages in the db dump are iterated over (optional)
+
+        Yields:
+            dict: the next comment in the reddit comments file; the comment's
+                content is in the 'body' field, all other fields are metadata
+        """
+        n_comments = 0
+        for comment in self:
+            comment['body'] = self._clean_content(comment['body'])
+            if len(comment['body']) < min_len:
+                continue
+
+            yield comment
+
+            n_comments += 1
+            if n_comments == limit:
+                break

--- a/textacy/corpora/reddit_reader.py
+++ b/textacy/corpora/reddit_reader.py
@@ -48,9 +48,14 @@ class RedditReader(object):
 
     def __iter__(self):
         for path in self.paths:
-            with bzip_open(path, mode='rt') as f:
-                for line in f:
-                    yield json.loads(line)
+            try:
+                with bzip_open(path, mode='rt') as f:
+                    for line in f:
+                        yield json.loads(line)
+            except ValueError:  # Python 2 sucks and can't open bzip in text mode
+                with bzip_open(path, mode='r') as f:
+                    for line in f:
+                        yield json.loads(line)
 
     def _clean_content(self, content):
         # strip out link markup, e.g. [foo](http://foo.com)

--- a/textacy/corpora/reddit_reader.py
+++ b/textacy/corpora/reddit_reader.py
@@ -18,6 +18,7 @@ until May 2015, as either plaintext strings or content + metadata dicts.
 Raw data is downloadable from https://archive.org/details/2015_reddit_comments_corpus.
 """
 import datetime
+import logging
 import json
 import re
 
@@ -25,6 +26,7 @@ from textacy.compat import bzip_open, str
 from textacy.preprocess import normalize_whitespace
 
 
+LOGGER = logging.getLogger(__name__)
 REDDIT_LINK_RE = re.compile(r'\[([^]]+)\]\(https?://[^\)]+\)')
 
 
@@ -53,7 +55,7 @@ class RedditReader(object):
                     for line in f:
                         yield json.loads(line)
             except ValueError:  # Python 2 sucks and can't open bzip in text mode
-                with bzip_open(path, mode='r') as f:
+                with bzip_open(path, mode='rb') as f:
                     for line in f:
                         yield json.loads(line)
 

--- a/textacy/corpora/reddit_reader.py
+++ b/textacy/corpora/reddit_reader.py
@@ -3,7 +3,9 @@ Reddit Corpus Reader
 --------------------
 
 Stream a corpus of up to ~1.6 billion Reddit comments posted from October 2007
-until May 2015, as either plaintext strings or content + metadata dicts.::
+until May 2015, as either plaintext strings or content + metadata dicts.
+
+.. code-block:: pycon
 
     >>> rr = RedditReader('/path/to/RC_2015-01.bz2')
     >>> for text in rr.texts(limit=5):  # plaintext comments

--- a/textacy/corpora/wiki_reader.py
+++ b/textacy/corpora/wiki_reader.py
@@ -194,7 +194,11 @@ class WikiReader(object):
         Notes:
             .. This function requires `mwparserfromhell <mwparserfromhell.readthedocs.org>`_
         """
-        import mwparserfromhell  # hiding this here; don't want another required dep
+        try:
+            import mwparserfromhell  # hiding this here; don't want another required dep
+        except ImportError:
+            print('mwparserfromhell package must be installed; see http://pythonhosted.org/mwparserfromhell/')
+            raise
         parser = mwparserfromhell.parser.Parser()
 
         n_pages = 0

--- a/textacy/corpora/wiki_reader.py
+++ b/textacy/corpora/wiki_reader.py
@@ -48,9 +48,14 @@ class WikiReader(object):
         Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
         yielding one (page id, title, page content) 3-tuple at a time.
         """
-        for title, content, page_id in extract_pages(bzip_open(self.wikicorpus.fname, mode='rt'),
-                                                     self.wikicorpus.filter_namespaces):
-            yield (page_id, title, content)
+        try:
+            for title, content, page_id in extract_pages(bzip_open(self.wikicorpus.fname, mode='rt'),
+                                                         self.wikicorpus.filter_namespaces):
+                yield (page_id, title, content)
+        except ValueError:  # Python 2 sucks and can't open bzip in text mode
+            for title, content, page_id in extract_pages(bzip_open(self.wikicorpus.fname, mode='r'),
+                                                         self.wikicorpus.filter_namespaces):
+                yield (page_id, title, content)
 
     def _clean_content(self, content):
         return WIKI_CRUFT_RE.sub(

--- a/textacy/corpora/wikipedia.py
+++ b/textacy/corpora/wikipedia.py
@@ -17,168 +17,169 @@ WIKI_QUOTE_RE = re.compile(r"'{2,3}")
 WIKI_CRUFT_RE = re.compile(r'\n\* ?')
 
 
-def _iterate_over_pages(fname):
-    """
-    Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
-    yielding one (page id, title, page content) 3-tuple at a time.
-    """
-    dictionary = Dictionary()
-    wiki = WikiCorpus(fname, lemmatize=False, dictionary=dictionary,
-                      filter_namespaces={'0'})
-    for title, content, page_id in extract_pages(bz2.BZ2File(wiki.fname), wiki.filter_namespaces):
-        yield (page_id, title, content)
+class WikiReader(object):
 
+    def __init__(self, path):
+        self.wikicorpus = WikiCorpus(path, lemmatize=False, dictionary=Dictionary(),
+                                     filter_namespaces={'0'})
 
-def _get_plaintext(content):
-    return WIKI_CRUFT_RE.sub(
-        r'', WIKI_NEWLINE_RE.sub(
-            r'\n', WIKI_HEADER_RE.sub(
-                r'\1', WIKI_QUOTE_RE.sub(
-                    r'', filter_wiki(content))))).strip()
+    def __iter__(self):
+        """
+        Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
+        yielding one (page id, title, page content) 3-tuple at a time.
+        """
+        for title, content, page_id in extract_pages(bz2.BZ2File(self.wikicorpus.fname),
+                                                     self.wikicorpus.filter_namespaces):
+            yield (page_id, title, content)
 
+    def _clean_content(self, content):
+        return WIKI_CRUFT_RE.sub(
+            r'', WIKI_NEWLINE_RE.sub(
+                r'\n', WIKI_HEADER_RE.sub(
+                    r'\1', WIKI_QUOTE_RE.sub(
+                        r'', filter_wiki(content))))).strip()
 
-def _parse_content(content, parser, metadata=True):
-    wikicode = parser.parse(content)
-    parsed_page = {'sections': []}
+    def _parse_content(self, content, parser, metadata=True):
+        wikicode = parser.parse(content)
+        parsed_page = {'sections': []}
 
-    if metadata is True:
-        wikilinks = [str(wc.title) for wc in wikicode.ifilter_wikilinks()]
-        parsed_page['categories'] = [wc for wc in wikilinks if wc.startswith('Category:')]
-        parsed_page['wiki_links'] = [wc for wc in wikilinks
-                                     if not wc.startswith('Category:')
-                                     and not wc.startswith('File:')
-                                     and not wc.startswith('Image:')]
-        parsed_page['ext_links'] = [str(wc.url) for wc in wikicode.ifilter_external_links()]
+        if metadata is True:
+            wikilinks = [str(wc.title) for wc in wikicode.ifilter_wikilinks()]
+            parsed_page['categories'] = [wc for wc in wikilinks if wc.startswith('Category:')]
+            parsed_page['wiki_links'] = [wc for wc in wikilinks
+                                         if not wc.startswith('Category:')
+                                         and not wc.startswith('File:')
+                                         and not wc.startswith('Image:')]
+            parsed_page['ext_links'] = [str(wc.url) for wc in wikicode.ifilter_external_links()]
 
-    def _filter_tags(obj):
-        return obj.tag == 'ref' or obj.tag == 'table'
+        def _filter_tags(obj):
+            return obj.tag == 'ref' or obj.tag == 'table'
 
-    bad_section_titles = {'external links', 'notes', 'references'}
-    section_idx = 0
+        bad_section_titles = {'external links', 'notes', 'references'}
+        section_idx = 0
 
-    for section in wikicode.get_sections(flat=True, include_lead=True, include_headings=True):
-        headings = section.filter_headings()
-        sec = {'idx': section_idx}
+        for section in wikicode.get_sections(flat=True, include_lead=True, include_headings=True):
+            headings = section.filter_headings()
+            sec = {'idx': section_idx}
 
-        if section_idx == 0 or len(headings) == 1:
-            try:
-                sec_title = str(headings[0].title)
-                if sec_title.lower() in bad_section_titles:
-                    continue
-                sec['title'] = sec_title
-                sec['level'] = int(headings[0].level)
-            except IndexError:
-                if section_idx == 0:
-                    sec['level'] = 1
-            # strip out references, tables, and file/image links
-            for obj in section.ifilter_tags(matches=_filter_tags, recursive=True):
-                section.remove(obj)
-            for obj in section.ifilter_wikilinks(recursive=True):
+            if section_idx == 0 or len(headings) == 1:
                 try:
-                    obj_title = str(obj.title)
-                    if obj_title.startswith('File:') or obj_title.startswith('Image:'):
-                        section.remove(obj)
-                except Exception:
-                    pass
-            sec['text'] = str(section.strip_code(normalize=True, collapse=True)).strip()
-            if sec.get('title'):
-                sec['text'] = re.sub(r'^'+re.escape(sec['title'])+r'\s*', '', sec['text'])
-            parsed_page['sections'].append(sec)
-            section_idx += 1
-
-        # dammit! the parser has failed us; let's handle it as best we can
-        elif len(headings) > 1:
-            titles = [str(h.title).strip() for h in headings]
-            levels = [int(h.level) for h in headings]
-            sub_sections = [str(ss) for ss in
-                            re.split(r'\s*'+'|'.join(re.escape(str(h)) for h in headings)+r'\s*', str(section))]
-            # re.split leaves an empty string result up front :shrug:
-            if sub_sections[0] == '':
-                del sub_sections[0]
-            if len(headings) != len(sub_sections):
-                print('# headings =', len(headings), '# sections =', len(sub_sections))
-            for i, sub_section in enumerate(sub_sections):
-                try:
-                    if titles[i].lower() in bad_section_titles:
+                    sec_title = str(headings[0].title)
+                    if sec_title.lower() in bad_section_titles:
                         continue
-                    parsed_page['sections'].append({'title': titles[i], 'level': levels[i], 'idx': section_idx,
-                                                    'text': _get_plaintext(sub_section)})
-                    section_idx += 1
+                    sec['title'] = sec_title
+                    sec['level'] = int(headings[0].level)
                 except IndexError:
-                    continue
+                    if section_idx == 0:
+                        sec['level'] = 1
+                # strip out references, tables, and file/image links
+                for obj in section.ifilter_tags(matches=_filter_tags, recursive=True):
+                    section.remove(obj)
+                for obj in section.ifilter_wikilinks(recursive=True):
+                    try:
+                        obj_title = str(obj.title)
+                        if obj_title.startswith('File:') or obj_title.startswith('Image:'):
+                            section.remove(obj)
+                    except Exception:
+                        pass
+                sec['text'] = str(section.strip_code(normalize=True, collapse=True)).strip()
+                if sec.get('title'):
+                    sec['text'] = re.sub(r'^'+re.escape(sec['title'])+r'\s*', '', sec['text'])
+                parsed_page['sections'].append(sec)
+                section_idx += 1
 
-    return parsed_page
+            # dammit! the parser has failed us; let's handle it as best we can
+            elif len(headings) > 1:
+                titles = [str(h.title).strip() for h in headings]
+                levels = [int(h.level) for h in headings]
+                sub_sections = [str(ss) for ss in
+                                re.split(r'\s*'+'|'.join(re.escape(str(h)) for h in headings)+r'\s*', str(section))]
+                # re.split leaves an empty string result up front :shrug:
+                if sub_sections[0] == '':
+                    del sub_sections[0]
+                if len(headings) != len(sub_sections):
+                    print('# headings =', len(headings), '# sections =', len(sub_sections))
+                for i, sub_section in enumerate(sub_sections):
+                    try:
+                        if titles[i].lower() in bad_section_titles:
+                            continue
+                        parsed_page['sections'].append({'title': titles[i], 'level': levels[i], 'idx': section_idx,
+                                                        'text': self._clean_content(sub_section)})
+                        section_idx += 1
+                    except IndexError:
+                        continue
 
+        return parsed_page
 
-def get_plaintext_pages(fname, min_len=100, max_n_pages=None):
-    """
-    Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
-    yielding one (page id, title, plaintext) 3-tuple at a time.
+    def texts(self, min_len=100, limit=None):
+        """
+        Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
+        yielding the plain text of a page, one at a time.
 
-    Args:
-        fname (str): full path/to/file for the database dump
-        min_len (int, optional): minimum length in chars that a page must have
-            for it to be returned; too-short pages are skipped
-        max_n_pages (int, optional): maximum number of pages (passing ``min_len``)
-            to yield; if None, all pages in the db dump are iterated over
+        Args:
+            min_len (int): minimum length in chars that a page must have
+                for it to be returned; too-short pages are skipped (optional)
+            limit (int): maximum number of pages (passing ``min_len``) to yield;
+                if None, all pages in the db dump are iterated over (optional)
 
-    Yields:
-        tuple(str, str, str): the next (page id, title, plaintext) 3-tuple
-            from the wikipedia articles database dump
-    """
-    n_pages = 0
-    for page_id, title, content in _iterate_over_pages(fname):
-        plaintext = _get_plaintext(content)
-        if len(plaintext) < min_len:
-            continue
-        n_pages += 1
-        if max_n_pages is not None and n_pages > max_n_pages:
-            break
+        Yields:
+            str: plain text for the next page in the wikipedia database dump
 
-        yield (page_id, title, plaintext)
+        Notes:
+            .. Page and section titles appear immediately before the text content
+               that they label, separated by a single newline character.
+        """
+        n_pages = 0
+        for _, title, content in self:
+            text = self._clean_content(content)
+            if len(text) < min_len:
+                continue
+            n_pages += 1
+            if limit is not None and n_pages > limit:
+                break
 
+            yield title + '\n' + text
 
-def get_parsed_pages(fname, min_len=100, max_n_pages=None, metadata=True):
-    """
-    Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
-    yielding one page whose structure and content have been parsed, as a dict.
+    def pages(self, min_len=100, limit=None, metadata=True):
+        """
+        Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
+        yielding one page whose structure and content have been parsed, as a dict.
 
-    Args:
-        fname (str): full path/to/file for the database dump
-        min_len (int, optional): minimum length in chars that a page must have
-            for it to be returned; too-short pages are skipped
-        max_n_pages (int, optional): maximum number of pages (passing ``min_len``)
-            to yield; if None, all pages in the db dump are iterated over
-        metadata (bool, optional): if True, return page metadata in addition to content,
-            including 'ext_links', 'wiki_links', and 'categories'
+        Args:
+            min_len (int, optional): minimum length in chars that a page must have
+                for it to be returned; too-short pages are skipped
+            limit (int, optional): maximum number of pages (passing ``min_len``)
+                to yield; if None, all pages in the db dump are iterated over
+            metadata (bool, optional): if True, return page metadata in addition to content,
+                including 'ext_links', 'wiki_links', and 'categories'
 
-    Yields:
-        dict: the next page's parsed content, including 'title' and 'page_id'
+        Yields:
+            dict: the next page's parsed content, including 'title' and 'page_id'
 
-            Key 'sections' includes a list of all page sections, each with 'title'
-            for the section title, 'text' for plain text content,'idx' for position
-            on page, and 'level' for the depth of the section within the page's hierarchy
+                Key 'sections' includes a list of all page sections, each with 'title'
+                for the section title, 'text' for plain text content,'idx' for position
+                on page, and 'level' for the depth of the section within the page's hierarchy
 
-            If ``metadata`` is True, there are additional keys: 'wiki_links' is
-            a list of _other_ page titles linked to from this page; 'ext_links' is
-            a list of external URLs linked to from this page; and 'categories' is
-            a list of Wikipedia categories to which this page belongs.
+                If ``metadata`` is True, there are additional keys: 'wiki_links' is
+                a list of _other_ page titles linked to from this page; 'ext_links' is
+                a list of external URLs linked to from this page; and 'categories' is
+                a list of Wikipedia categories to which this page belongs.
 
-    Notes:
-        .. This function requires `mwparserfromhell <mwparserfromhell.readthedocs.org>`_
-    """
-    import mwparserfromhell  # hiding this here; don't want another required dep
-    parser = mwparserfromhell.parser.Parser()
+        Notes:
+            .. This function requires `mwparserfromhell <mwparserfromhell.readthedocs.org>`_
+        """
+        import mwparserfromhell  # hiding this here; don't want another required dep
+        parser = mwparserfromhell.parser.Parser()
 
-    n_pages = 0
-    for page_id, title, content in _iterate_over_pages(fname):
-        parsed_page = _parse_content(content, parser, metadata=metadata)
-        if len(' '.join(s['text'] for s in parsed_page['sections'])) < min_len:
-            continue
-        n_pages += 1
-        parsed_page['title'] = title
-        parsed_page['page_id'] = page_id
-        if max_n_pages is not None and n_pages > max_n_pages:
-            break
+        n_pages = 0
+        for page_id, title, content in self:
+            page = self._parse_content(content, parser, metadata=metadata)
+            if len(' '.join(s['text'] for s in page['sections'])) < min_len:
+                continue
+            n_pages += 1
+            page['title'] = title
+            page['page_id'] = page_id
+            if limit is not None and n_pages > limit:
+                break
 
-        yield parsed_page
+            yield page

--- a/textacy/corpora/wikipedia.py
+++ b/textacy/corpora/wikipedia.py
@@ -111,7 +111,7 @@ class WikiReader(object):
 
         return parsed_page
 
-    def texts(self, min_len=100, limit=None):
+    def texts(self, min_len=100, limit=-1):
         """
         Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
         yielding the plain text of a page, one at a time.
@@ -119,8 +119,8 @@ class WikiReader(object):
         Args:
             min_len (int): minimum length in chars that a page must have
                 for it to be returned; too-short pages are skipped (optional)
-            limit (int): maximum number of pages (passing ``min_len``) to yield;
-                if None, all pages in the db dump are iterated over (optional)
+            limit (int): maximum number of pages (passing `min_len`) to yield;
+                if -1, all pages in the db dump are iterated over (optional)
 
         Yields:
             str: plain text for the next page in the wikipedia database dump
@@ -134,24 +134,25 @@ class WikiReader(object):
             text = self._clean_content(content)
             if len(text) < min_len:
                 continue
-            n_pages += 1
-            if limit is not None and n_pages > limit:
-                break
 
             yield title + '\n' + text
 
-    def pages(self, min_len=100, limit=None, metadata=True):
+            n_pages += 1
+            if n_pages == limit:
+                break
+
+    def pages(self, min_len=100, limit=-1, metadata=True):
         """
         Iterate over the pages in a Wikipedia articles database dump (*articles.xml.bz2),
         yielding one page whose structure and content have been parsed, as a dict.
 
         Args:
-            min_len (int, optional): minimum length in chars that a page must have
+            min_len (int): minimum length in chars that a page must have
                 for it to be returned; too-short pages are skipped
-            limit (int, optional): maximum number of pages (passing ``min_len``)
-                to yield; if None, all pages in the db dump are iterated over
-            metadata (bool, optional): if True, return page metadata in addition to content,
-                including 'ext_links', 'wiki_links', and 'categories'
+            limit (int): maximum number of pages (passing ``min_len``) to yield;
+                if -1, all pages in the db dump are iterated over (optional)
+            metadata (bool): if True, return page metadata in addition to content,
+                including 'ext_links', 'wiki_links', and 'categories' (optional)
 
         Yields:
             dict: the next page's parsed content, including 'title' and 'page_id'
@@ -176,10 +177,11 @@ class WikiReader(object):
             page = self._parse_content(content, parser, metadata=metadata)
             if len(' '.join(s['text'] for s in page['sections'])) < min_len:
                 continue
-            n_pages += 1
             page['title'] = title
             page['page_id'] = page_id
-            if limit is not None and n_pages > limit:
-                break
 
             yield page
+
+            n_pages += 1
+            if n_pages == limit:
+                break


### PR DESCRIPTION
Prompted by Issue #13 .

Changes:

- Added a class, `corpora.RedditReader()`, for streaming Reddit comments from disk, with a simple interface of `.texts()` for a stream of plaintext comments and `.comments()` for a stream of structured comments as dicts, with basic filtering by text length and limiting the number of comments returned
    - added a testcase, but had to comment them out on account of python idiocy; will deal with later when I have more patience for it
- Refactored functions for streaming Wikipedia articles from disk into a class, `corpora.WikiReader()`, with `.texts()` for a stream of plaintext articles and `.pages()` for a stream of structured pages as dicts, with basic filtering by text length and limiting the number of pages returned
    - added a testcase, and it works; huzzah

@danvalente, I know you're busy, but would you be able to take a quick look...?