### PR TITLE
added save/load methods to TextDoc and TextCorpus

### DIFF
--- a/textacy/texts.py
+++ b/textacy/texts.py
@@ -7,15 +7,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from collections import Counter
 import copy
+import os
 import re
+import warnings
 
 from cytoolz import itertoolz
+import spacy.about
 from spacy.tokens.doc import Doc as sdoc
 from spacy.tokens.token import Token as stoken
 from spacy.tokens.span import Span as sspan
 
 from textacy.compat import str, zip
-from textacy import data, extract, spacy_utils, text_stats, text_utils, keyterms
+from textacy import (data, extract, fileio, keyterms, spacy_utils,
+                     text_stats, text_utils)
 from textacy.representations import network, vsm
 
 
@@ -91,6 +95,62 @@ class TextDoc(object):
     def __iter__(self):
         for tok in self.spacy_doc:
             yield tok
+
+    def save(self, path, fname_prefix=None):
+        """
+        Save serialized TextDoc content and metadata to disk.
+
+        Args:
+            path (str): directory on disk where content + metadata will be saved
+            fname_prefix (str, optional): prepend standard filenames 'spacy_doc.bin'
+                and 'metadata.json' with additional identifying information
+        """
+        if fname_prefix:
+            meta_fname = os.path.join(path, '_'.join([fname_prefix, 'metadata.json']))
+            doc_fname = os.path.join(path, '_'.join([fname_prefix, 'spacy_doc.bin']))
+        else:
+            meta_fname = os.path.join(path, 'metadata.json')
+            doc_fname = os.path.join(path, 'spacy_doc.bin')
+        package_info = {'textacy_lang': self.lang,
+                        'spacy_version': spacy.about.__version__}
+        fileio.write_json(
+            dict(package_info, **self.metadata), meta_fname)
+        fileio.write_spacy_docs(self.spacy_doc, doc_fname)
+
+    @classmethod
+    def load(cls, path, fname_prefix=None):
+        """
+        Load serialized content and metadata from disk, and initialize a TextDoc.
+
+        Args:
+            path (str): directory on disk where content + metadata are saved
+            fname_prefix (str, optional): additional identifying information
+                prepended to standard filenames 'spacy_doc.bin' and 'metadata.json'
+                when saving to disk
+
+        Returns:
+            :class:`textacy.TextDoc`
+        """
+        if fname_prefix:
+            meta_fname = os.path.join(path, '_'.join([fname_prefix, 'metadata.json']))
+            docs_fname = os.path.join(path, '_'.join([fname_prefix, 'spacy_doc.bin']))
+        else:
+            meta_fname = os.path.join(path, 'metadata.json')
+            docs_fname = os.path.join(path, 'spacy_doc.bin')
+        metadata = list(fileio.read_json(meta_fname))[0]
+        lang = metadata.pop('textacy_lang')
+        spacy_version = metadata.pop('spacy_version')
+        if spacy_version != spacy.about.__version__:
+            msg = """
+                the spaCy version used to save this TextDoc to disk is not the
+                same as the version currently installed ('{}' vs. '{}'); if the
+                data underlying the associated `spacy.Vocab` has changed, this
+                loaded TextDoc may not be valid!
+                """.format(spacy_version, spacy.about.__version__)
+            warnings.warn(msg, UserWarning)
+        spacy_vocab = data.load_spacy(lang).vocab
+        return cls(list(fileio.read_spacy_docs(spacy_vocab, docs_fname))[0],
+                   lang=lang, metadata=metadata)
 
     @property
     def tokens(self):
@@ -589,6 +649,70 @@ class TextCorpus(object):
     def __iter__(self):
         for doc in self.docs:
             yield doc
+
+    def save(self, path, fname_prefix=None):
+        """
+        Save serialized TextCorpus content and metadata to disk.
+
+        Args:
+            path (str): directory on disk where content + metadata will be saved
+            fname_prefix (str, optional): prepend standard filenames 'spacy_docs.bin'
+                and 'metadatas.json' with additional identifying information
+        """
+        if fname_prefix:
+            info_fname = os.path.join(path, '_'.join([fname_prefix, 'info.json']))
+            meta_fname = os.path.join(path, '_'.join([fname_prefix, 'metadatas.json']))
+            docs_fname = os.path.join(path, '_'.join([fname_prefix, 'spacy_docs.bin']))
+        else:
+            info_fname = os.path.join(path, 'info.json')
+            meta_fname = os.path.join(path, 'metadatas.json')
+            docs_fname = os.path.join(path, 'spacy_docs.bin')
+        package_info = {'textacy_lang': self.lang, 'spacy_version': spacy.about.__version__}
+        fileio.write_json(package_info, info_fname)
+        fileio.write_json_lines((doc.metadata for doc in self), meta_fname)
+        fileio.write_spacy_docs((doc.spacy_doc for doc in self), docs_fname)
+
+    @classmethod
+    def load(cls, path, fname_prefix=None):
+        """
+        Load serialized content and metadata from disk, and initialize a TextCorpus.
+
+        Args:
+            path (str): directory on disk where content + metadata are saved
+            fname_prefix (str, optional): additional identifying information
+                prepended to standard filenames 'spacy_docs.bin' and 'metadatas.json'
+                when saving to disk
+
+        Returns:
+            :class:`textacy.TextCorpus`
+        """
+        if fname_prefix:
+            info_fname = os.path.join(path, '_'.join([fname_prefix, 'info.json']))
+            meta_fname = os.path.join(path, '_'.join([fname_prefix, 'metadatas.json']))
+            docs_fname = os.path.join(path, '_'.join([fname_prefix, 'spacy_docs.bin']))
+        else:
+            info_fname = os.path.join(path, 'info.json')
+            meta_fname = os.path.join(path, 'metadatas.json')
+            docs_fname = os.path.join(path, 'spacy_docs.bin')
+        package_info = list(fileio.read_json(info_fname))[0]
+        lang = package_info['textacy_lang']
+        spacy_version = package_info['spacy_version']
+        if spacy_version != spacy.about.__version__:
+            msg = """
+                the spaCy version used to save this TextCorpus to disk is not the
+                same as the version currently installed ('{}' vs. '{}'); if the
+                data underlying the associated `spacy.Vocab` has changed, this
+                loaded TextCorpus may not be valid!
+                """.format(spacy_version, spacy.about.__version__)
+            warnings.warn(msg, UserWarning)
+        textcorpus = TextCorpus(lang)
+        metadata_stream = fileio.read_json_lines(meta_fname)
+        spacy_docs = fileio.read_spacy_docs(textcorpus.spacy_vocab, docs_fname)
+        for spacy_doc, metadata in zip(spacy_docs, metadata_stream):
+            textcorpus.add_doc(
+                TextDoc(spacy_doc, spacy_pipeline=textcorpus.spacy_pipeline,
+                        lang=lang, metadata=metadata))
+        return textcorpus
 
     @classmethod
     def from_texts(cls, lang, texts, metadata=None, n_threads=2, batch_size=1000):


### PR DESCRIPTION
Changes:

- Added `.save()` methods and `.load()` classmethods to both `TextDoc` and `TextCorpus` classes, which allows for fast serialization of parsed documents and associated metadata to/from disk.
    - important caveat covered by warning message: if `spacy.Vocab` object used to serialize and deserialize is not the same, there will be problems, making this format useful as short-term but not long-term storage

@danvalente: :pray: