### PR TITLE
document, set, and string distance metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ matplotlib
 networkx
 numpy>=1.8.0
 pyphen
+python-levenshtein>=0.12.0
 scipy
 scikit-learn>=0.17.0
 spacy>=0.101.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools
 cld2-cffi
 cytoolz
 ftfy
-fuzzywuzzy
+fuzzywuzzy>=0.10.0
 gensim
 ijson
 matplotlib

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+import textacy
+
+
+class DistanceTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.text1 = 'She spoke to the assembled journalists.'
+        self.text2 = 'He chatted with the gathered press.'
+        self.doc1 = textacy.TextDoc(self.text1, lang='en')
+        self.doc2 = textacy.TextDoc(self.text2, lang='en')
+
+    def test_word_movers_distance(self):
+        metrics = ('cosine', 'l1', 'manhattan', 'l2', 'euclidean')
+        expected_values = (0.467695, 0.655712, 0.655712, 0.668999, 0.668999)
+        for metric, expected_value in zip(metrics, expected_values):
+            self.assertAlmostEqual(
+                textacy.distance.word_movers_distance(self.doc1, self.doc2, metric=metric),
+                expected_value,
+                places=4)
+
+    def test_word2vec_distance(self):
+        pairs = ((self.doc1, self.doc2),
+                 (self.doc1[-2:], self.doc2[-2:]),
+                 (self.doc1[-1], self.doc2[-1]))
+        expected_values = (0.089036, 0.238299, 0.500000)
+        for pair, expected_value in zip(pairs, expected_values):
+            self.assertAlmostEqual(
+                textacy.distance.word2vec_distance(pair[0], pair[1]),
+                expected_value,
+                places=4)
+
+    def test_jaccard_distance(self):
+        pairs = ((self.text1, self.text2),
+                 (self.text1.split(), self.text2.split()))
+        expected_values = (0.541666, 0.909090)
+        for pair, expected_value in zip(pairs, expected_values):
+            self.assertAlmostEqual(
+                textacy.distance.jaccard_distance(pair[0], pair[1]),
+                expected_value,
+                places=4)
+
+    def test_jaccard_distance_exception(self):
+        self.assertRaises(
+            ValueError, textacy.distance.jaccard_distance,
+            self.text1, self.text2, True)
+
+    def test_jaccard_distance_fuzzy_match(self):
+        thresholds = (50, 70, 90)
+        expected_values = (0.545454, 0.727272, 0.909090)
+        for thresh, expected_value in zip(thresholds, expected_values):
+            self.assertAlmostEqual(
+                textacy.distance.jaccard_distance(self.text1.split(), self.text2.split(),
+                                                  fuzzy_match=True, match_threshold=thresh),
+                expected_value,
+                places=4)
+
+    def test_hamming_distance(self):
+        self.assertEqual(
+            textacy.distance.hamming_distance(self.text1, self.text2),
+            34)
+        self.assertEqual(
+            textacy.distance.hamming_distance(self.text1, self.text2, normalize=True),
+            0.8717948717948718)
+
+    def test_levenshtein_distance(self):
+        self.assertEqual(
+            textacy.distance.levenshtein_distance(self.text1, self.text2),
+            25)
+        self.assertEqual(
+            textacy.distance.levenshtein_distance(self.text1, self.text2, normalize=True),
+            0.6410256410256411)
+
+    def test_jaro_winkler_distance(self):
+        self.assertEqual(
+            textacy.distance.jaro_winkler_distance(self.text1, self.text2),
+            0.4281995781995781)

--- a/textacy/__init__.py
+++ b/textacy/__init__.py
@@ -17,7 +17,7 @@ from textacy import compat, data, math_utils, regexes_etc
 from textacy import lexicon_methods, preprocess, text_stats, text_utils
 from textacy import spacy_utils
 from textacy import extract
-from textacy import export, keyterms
+from textacy import distance, export, keyterms
 from textacy import texts
 
 from textacy.data import load_spacy

--- a/textacy/distance.py
+++ b/textacy/distance.py
@@ -1,0 +1,52 @@
+"""
+collection of semantic distance metrics...
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import collections
+
+from cytoolz import itertoolz
+import numpy as np
+from pyemd import emd
+from sklearn.metrics import pairwise_distances
+from spacy.strings import StringStore
+
+
+def word_movers_distance(doc1, doc2, metric='cosine'):
+    """
+    Args:
+        doc1 (`TextDoc`)
+        doc2 (`TextDoc`)
+        metric (str): valid options are {'cosine', 'euclidean', 'l1', 'l2', 'manhattan'}
+
+    Returns:
+        float: distance between `doc1` and `doc2` in [0.0, 1.0];
+            returns 0.0 for identical documents
+    """
+    stringstore = StringStore()
+
+    n = 0
+    word_vecs = []
+    for word in itertoolz.concatv(doc1.words(), doc2.words()):
+        if word.has_vector:
+            if stringstore[word.text] - 1 == n:
+                word_vecs.append(word.vector)
+                n += 1
+    distance_mat = pairwise_distances(np.array(word_vecs), metric=metric).astype(np.double)
+    distance_mat /= distance_mat.max()
+
+    vec1 = collections.Counter(
+        stringstore[word.text] - 1
+        for word in doc1.words()
+        if word.has_vector)
+    vec1 = np.array([vec1[word_idx] for word_idx in range(len(stringstore))]).astype(np.double)
+    vec1 /= vec1.sum()  # normalize word counts
+
+    vec2 = collections.Counter(
+        stringstore[word.text] - 1
+        for word in doc2.words()
+        if word.has_vector)
+    vec2 = np.array([vec2[word_idx] for word_idx in range(len(stringstore))]).astype(np.double)
+    vec2 /= vec2.sum()  # normalize word counts
+
+    return emd(vec1, vec2, distance_mat)

--- a/textacy/distance.py
+++ b/textacy/distance.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import collections
 
 from cytoolz import itertoolz
+from fuzzywuzzy import fuzz
 import numpy as np
 from pyemd import emd
 from sklearn.metrics import pairwise_distances
@@ -14,14 +15,16 @@ from spacy.strings import StringStore
 
 def word_movers_distance(doc1, doc2, metric='cosine'):
     """
+    Measure the semantic distance between two documents using Word Movers Distance.
+
     Args:
         doc1 (`TextDoc`)
         doc2 (`TextDoc`)
-        metric (str): valid options are {'cosine', 'euclidean', 'l1', 'l2', 'manhattan'}
+        metric ({'cosine', 'euclidean', 'l1', 'l2', 'manhattan'})
 
     Returns:
-        float: distance between `doc1` and `doc2` in [0.0, 1.0];
-            returns 0.0 for identical documents
+        float: distance between `doc1` and `doc2` in [0.0, 1.0], where 0.0
+            indicates that the documents are the same
     """
     stringstore = StringStore()
 
@@ -50,3 +53,35 @@ def word_movers_distance(doc1, doc2, metric='cosine'):
     vec2 /= vec2.sum()  # normalize word counts
 
     return emd(vec1, vec2, distance_mat)
+
+
+def jaccard_distance(vec1, vec2, fuzzy_match=False, match_threshold=80):
+    """
+    Measure the semantic distance between two vectors of strings using Jaccard
+    distance, with optional fuzzy matching of not-identical pairs.
+
+    Args:
+        vec1 (sequence(str))
+        vec2 (sequence(str))
+        fuzzy_match (bool): if True, allow for fuzzy matching in addition to the
+            usual identical matching of pairs between input vectors
+        match_threshold (int): value in the interval [0, 100]; fuzzy comparisons
+            with a score >= this value will be considered matches
+
+    Returns:
+        float: distance between `vec1` and `vec2` in [0.0, 1.0], where 0.0
+            indicates that the documents are the same
+    """
+    set1 = set(vec1)
+    set2 = set(vec2)
+    intersection = len(set1 & set2)
+    union = len(set1 | set2)
+    if fuzzy_match is True:
+        for item1 in set1.difference(set2):
+            if max(fuzz.token_sort_ratio(item1, item2) for item2 in set2) >= match_threshold:
+                intersection += 1
+        for item2 in set2.difference(set1):
+            if max(fuzz.token_sort_ratio(item2, item1) for item1 in set1) >= match_threshold:
+                intersection += 1
+
+    return 1.0 - (intersection / union)

--- a/textacy/math_utils.py
+++ b/textacy/math_utils.py
@@ -6,6 +6,7 @@ from __future__ import division
 import numpy as np
 
 # TODO: make this module actually good and useful
+# UPDATE: this module is still an orphan. Burton, get on it!
 
 
 def cosine_similarity(vec1, vec2):
@@ -20,29 +21,3 @@ def cosine_similarity(vec1, vec2):
         float
     """
     return np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2))
-
-
-def levenshtein_distance(str1, str2):
-    """
-    Function to find the Levenshtein distance between two words/sentences;
-    gotten from http://rosettacode.org/wiki/Levenshtein_distance#Python
-
-    Args:
-        str1 (str)
-        str2 (str)
-
-    Returns:
-        int
-    """
-    if len(str1) > len(str2):
-        str1, str2 = str2, str1
-    distances = range(len(str1) + 1)
-    for index2, char2 in enumerate(str2):
-        new_distances = [index2 + 1]
-        for index1, char1 in enumerate(str1):
-            if char1 == char2:
-                new_distances.append(distances[index1])
-            else:
-                new_distances.append(1 + min((distances[index1], distances[index1 + 1], new_distances[-1])))
-        distances = new_distances
-    return distances[-1]

--- a/textacy/texts.py
+++ b/textacy/texts.py
@@ -606,7 +606,7 @@ class TextCorpus(object):
         Returns:
             :class:`TextCorpus <textacy.texts.TextCorpus>`
         """
-        textcorpus = cls(lang=lang)
+        textcorpus = cls(lang)
         spacy_docs = textcorpus.spacy_pipeline.pipe(
             texts, n_threads=n_threads, batch_size=batch_size)
         if metadata is not None:
@@ -643,7 +643,10 @@ class TextCorpus(object):
         doc.corpus = self
         self.docs.append(doc)
         self.n_docs += 1
-        self.n_sents += doc.n_sents
+        try:
+            self.n_sents += doc.n_sents
+        except ValueError:  # no parser loaded, skip it
+            pass
         self.n_tokens += doc.n_tokens
 
     def add_doc(self, doc, print_warning=True):
@@ -670,7 +673,10 @@ class TextCorpus(object):
         doc.corpus = self
         self.docs.append(doc)
         self.n_docs += 1
-        self.n_sents += doc.n_sents
+        try:
+            self.n_sents += doc.n_sents
+        except ValueError:  # no parser loaded, skip it
+            pass
         self.n_tokens += doc.n_tokens
 
     def get_doc(self, index):


### PR DESCRIPTION
Changes:

- Added a `distance.py` module containing several document, set, and string distance metrics
    - word movers distance: document distance as distance between individual words represented by word2vec vectors, normalized
    - "word2vec" distance: token, span, or document distance as cosine distance between (average) word2vec representations, normalized
    - jaccard distance: string or set(string) distance as intersection / overlap, normalized, with optional fuzzy-matching across set members
    - hamming: distance between two strings as number of substititions, optionally normalized
    - levenshtein: distance between two strings as number of substitions, deletions, and insertions, optionally normalized
    - jaro-winkler: distance between two strings with variable prefix weighting, normalized

TODO:
- add tests! soon...

@danvalente @jeiranj -- care to take a look?