### PR TITLE
Added CapitolWords corpus

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,18 +6,19 @@ dev
 
 Changes:
 
-- refactored and improved `fileio` subpackage
+- Added the CapitolWords corpus, a collection of 11k speeches (~7M tokens) given by the main protagonists of the 2016 U.S. Presidential election that had previously served in the U.S. Congress — including Hillary Clinton, Bernie Sanders, Barack Obama, Ted Cruz, and John Kasich — from January 1996 through June 2016
+    - DEPRECATED the Bernie and Hillary corpus, which is a small subset of CapitolWords
+- Refactored and improved `fileio` subpackage
     - moved shared (read/write) functions into separate `fileio.utils` module
-    - almost all read/write functions now use `fileio.utils.open_sesame()`, enabling seamless fileio for uncompressed or gzip, bz2, and lzma compressed files; relative/user-home-based paths; and missing intermediate directories
+    - almost all read/write functions now use `fileio.utils.open_sesame()`, enabling seamless fileio for uncompressed or gzip, bz2, and lzma compressed files; relative/user-home-based paths; and missing intermediate directories. NOTE: certain file mode / compression pairs simply don't work (this is Python's fault), so users may run into exceptions; in Python 3, you'll almost always want to use text mode ('wt' or 'rt'), but in Python 2, users can't read or write compressed files in text mode, only binary mode ('wb' or 'rb')
     - added options for writing json files (matching stdlib's `json.dump()`) that can help save space
     - `fileio.utils.get_filenames()` now matches for/against a regex pattern rather than just a contained substring; using the old params will now raise a deprecation warning
-    - BREAKING: `fileio.utils.split_content_and_metadata()` now has `itemwise=False` by default, rather than `itemwise=True`, which means that splitting multi-document streams of content and metadata into parallel iterators is now the default action
-    - NOTE: certain file mode / compression pairs simply don't work (this is Python's fault), so users may run into exceptions; in Python 3, you'll almost always want to use text mode ('wt' or 'rt'), but in Python 2, users can't read or write compressed files in text mode, only binary mode ('wb' or 'rb')
-- cleaned up deprecated/bad Py2/3 `compat` imports, and added better functionality for Py2/3 strings
+    - *BREAKING:* `fileio.utils.split_content_and_metadata()` now has `itemwise=False` by default, rather than `itemwise=True`, which means that splitting multi-document streams of content and metadata into parallel iterators is now the default action
+    - added `compression` param to `TextCorpus.save()` and `.load()` to optionally write metadata json file in compressed form
+    - moved `fileio.write_conll()` functionality to `export.doc_to_conll()`, which converts a spaCy doc into a ConLL-U formatted string; writing that string to disk would require a separate call to `fileio.write_file()`
+- Cleaned up deprecated/bad Py2/3 `compat` imports, and added better functionality for Py2/3 strings
     - now `compat.unicode_type` used for text data, `compat.bytes_type` for binary data, and `compat.string_types` for when either will do
     - also added `compat.unicode_to_bytes()` and `compat.bytes_to_unicode()` functions, for converting between string types
-- added `compression` param to `TextCorpus.save()` and `.load()` to optionally write metadata json file in compressed form
-- moved `fileio.write_conll()` functionality to `export.doc_to_conll()`, which converts a spaCy doc into a ConLL-U formatted string; writing that string to disk would require a separate call to `fileio.write_file()`
 
 Bugfixes:
 

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -49,6 +49,9 @@ File IO
 Corpora
 -------
 
+.. automodule:: textacy.corpora.capitolwords
+    :members:
+
 .. automodule:: textacy.corpora.bernie_and_hillary
     :members:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ numpy>=1.8.0
 pyemd>=0.3.0
 pyphen
 python-levenshtein>=0.12.0
+requests>=2.10.0
 scipy
 scikit-learn>=0.17.0
 spacy>=0.101.0

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'pyemd>=0.3.0',
         'pyphen',
         'python-levenshtein>=0.12.0',
+        'requests>=2.10.0',
         'scipy',
         'scikit-learn',
         'spacy>=0.101.0',

--- a/tests/test_capitolwords.py
+++ b/tests/test_capitolwords.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import, unicode_literals
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from textacy.compat import unicode_type
+from textacy.corpora import capitolwords
+
+
+class CapitolWordsTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp(
+            prefix='test_corpora', dir=os.path.dirname(os.path.abspath(__file__)))
+
+    def test_capitolwords_oserror(self):
+        self.assertRaises(
+            OSError, capitolwords.CapitolWords,
+            self.tempdir, False)
+
+    @unittest.skip("no need to download a fresh corpus every time")
+    def test_capitolwords_download(self):
+        capitolwords.CapitolWords(
+            data_dir=self.tempdir, download_if_missing=True)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.tempdir, 'capitolwords', capitolwords.FILENAME)))
+
+    def test_capitolwords_texts(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        for text in cw.texts(limit=3):
+            self.assertIsInstance(text, unicode_type)
+
+    def test_capitolwords_texts_limit(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        for limit in (1, 5, 100):
+            self.assertEqual(sum(1 for _ in cw.texts(limit=limit)), limit)
+
+    def test_capitolwords_texts_min_len(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        for min_len in (100, 200, 1000):
+            self.assertTrue(
+                all(len(text) >= min_len
+                    for text in cw.texts(min_len=min_len, limit=1000)))
+
+    def test_capitolwords_docs(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        for doc in cw.docs(limit=3):
+            self.assertIsInstance(doc, dict)
+
+    def test_capitolwords_docs_speaker_name(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        speaker_names = ({'Bernie Sanders'}, {'Ted Cruz', 'Barack Obama'})
+        for speaker_name in speaker_names:
+            self.assertTrue(
+                all(d['speaker_name'] in speaker_name
+                    for d in cw.docs(speaker_name=speaker_name, limit=1000)))
+
+    def test_capitolwords_docs_speaker_party(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        speaker_parties = ({'R'}, {'D', 'I'})
+        for speaker_party in speaker_parties:
+            self.assertTrue(
+                all(d['speaker_party'] in speaker_party
+                    for d in cw.docs(speaker_party=speaker_party, limit=1000)))
+
+    def test_capitolwords_docs_chamber(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        chambers = ({'House'}, {'House', 'Senate'})
+        for chamber in chambers:
+            self.assertTrue(
+                all(d['chamber'] in chamber
+                    for d in cw.docs(chamber=chamber, limit=1000)))
+
+    def test_capitolwords_docs_congress(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        congresses = ({104}, {104, 114})
+        for congress in congresses:
+            self.assertTrue(
+                all(d['congress'] in congress
+                    for d in cw.docs(congress=congress, limit=1000)))
+
+    def test_capitolwords_bad_filters(self):
+        cw = capitolwords.CapitolWords(download_if_missing=True)
+        bad_filters = ({'speaker_name': 'Burton DeWilde'},
+                       {'speaker_party': 'Whigs'},
+                       {'chamber': 'Pot'},
+                       {'congress': 42},
+                       {'date_range': '2016-01-01'})
+        for bad_filter in bad_filters:
+            with self.assertRaises(ValueError):
+                list(cw._iterate(True, **bad_filter))
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)

--- a/textacy/__init__.py
+++ b/textacy/__init__.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 __version__ = '0.2.5'
-__data_dir__ = os.path.join(os.path.dirname(__file__), 'resources')
+__resources_dir__ = os.path.join(os.path.dirname(__file__), 'resources')
 
 # subpackages
 from textacy import corpora

--- a/textacy/corpora/__init__.py
+++ b/textacy/corpora/__init__.py
@@ -1,3 +1,4 @@
 from .wiki_reader import WikiReader
 from .reddit_reader import RedditReader
 from .bernie_and_hillary import fetch_bernie_and_hillary
+from .capitolwords import CapitolWords

--- a/textacy/corpora/bernie_and_hillary.py
+++ b/textacy/corpora/bernie_and_hillary.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 URL = 'https://s3.amazonaws.com/chartbeat-labs/bernie_and_hillary.json'
 FNAME = 'bernie_and_hillary.json'
-DEFAULT_DATA_DIR = os.path.join(textacy.__data_dir__, 'bernie_and_hillary')
+DEFAULT_DATA_DIR = os.path.join(textacy.__resources_dir__, 'bernie_and_hillary')
 
 
 def _download_bernie_and_hillary(data_dir):

--- a/textacy/corpora/bernie_and_hillary.py
+++ b/textacy/corpora/bernie_and_hillary.py
@@ -32,6 +32,7 @@ try:
 except ImportError:
     from urllib2 import urlopen
     from urllib2 import HTTPError
+import warnings
 
 import textacy
 from textacy.fileio import read_json_lines, write_file
@@ -88,7 +89,20 @@ def fetch_bernie_and_hillary(data_dir=None,
         IOError: if file is not found on disk and `download_if_missing` is False
         HTTPError: if file is not found on disk, `download_if_missing` is True,
             and something goes wrong with the download
+
+    .. warn:: The Bernie & Hillary corpus has been deprecated! Use the newer and
+        more comprehensive CapitolWords corpus instead. To recreate B&H, filter
+        CapitolWords speeches by `speaker_name={'Bernie Sanders', 'Hillary Clinton'}`.
     """
+    with warnings.catch_warnings():
+        warnings.simplefilter('always', DeprecationWarning)
+        msg = """
+            The Bernie & Hillary corpus has been deprecated! Use the newer and
+            more comprehensive CapitolWords corpus instead. To recreate B&H,
+            filter CapitolWords speeches by `speaker_name={'Bernie Sanders', 'Hillary Clinton'}`.
+            """
+        warnings.warn(msg.strip(),
+                      DeprecationWarning)
     if data_dir is None:
         data_dir = DEFAULT_DATA_DIR
     fname = os.path.join(data_dir, FNAME)

--- a/textacy/corpora/capitolwords.py
+++ b/textacy/corpora/capitolwords.py
@@ -110,8 +110,8 @@ class CapitolWords(object):
 
     def __init__(self, data_dir=None, download_if_missing=True):
         if data_dir is None:
-            _data_dir = __resources_dir__
-        self.filepath = os.path.join(_data_dir, 'capitolwords', FILENAME)
+            data_dir = __resources_dir__
+        self.filepath = os.path.join(data_dir, 'capitolwords', FILENAME)
         if not os.path.exists(self.filepath):
             if download_if_missing is True:
                 self._download_data()
@@ -213,10 +213,11 @@ class CapitolWords(object):
             limit (int): return no more than `limit` speeches, in order of date
 
         Yields:
-            str
+            str: full text of next (by chronological order) speech in corpus
+                passing all filter params
 
         Raises:
-            ValueError
+            ValueError: if any filtering options are invalid
         """
         texts = self._iterate(
             True, speaker_name=speaker_name, speaker_party=speaker_party,
@@ -250,10 +251,11 @@ class CapitolWords(object):
             limit (int): return no more than `limit` speeches, in order of date
 
         Yields:
-            dict
+            dict: full text and metadata of next (by chronological order) speech
+                in corpus passing all filter params
 
         Raises:
-            ValueError
+            ValueError: if any filtering options are invalid
         """
         docs = self._iterate(
             False, speaker_name=speaker_name, speaker_party=speaker_party,

--- a/textacy/corpora/capitolwords.py
+++ b/textacy/corpora/capitolwords.py
@@ -41,6 +41,9 @@ else:
     URL = 'https://cdn.rawgit.com/chartbeat-labs/textacy/5156197facb98f767f5d92ffa299d266bd50cf6b/data/capitol-words-py3.json.gz'
 FILENAME = URL.rsplit('/', 1)[-1]
 
+MIN_DATE = '1996-01-01'
+MAX_DATE = '2016-06-30'
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -122,25 +125,92 @@ class CapitolWords(object):
         with io.open(self.filepath, mode='wb') as f:
             f.write(response.content)
 
-    def __iter__(self):
+    def _iterate(self, text_only, speaker_name=None, speaker_party=None,
+                 chamber=None, congress=None, date_range=None, min_len=None,
+                 limit=-1):
+        """Note: Use `.texts()` or `.docs()` to iterate over corpus data."""
+        # prepare filters
+        if speaker_name:
+            if isinstance(speaker_name, string_types):
+                speaker_name = {speaker_name}
+            if not all(item in self.speaker_names for item in speaker_name):
+                raise ValueError(
+                    'all values in `speaker_name` must be valid; see `CapitolWords.speaker_names`')
+        if speaker_party:
+            if isinstance(speaker_party, string_types):
+                speaker_party = {speaker_party}
+            if not all(item in self.speaker_parties for item in speaker_party):
+                raise ValueError(
+                    'all values in `speaker_party` must be valid; see `CapitolWords.speaker_parties`')
+        if chamber:
+            if isinstance(chamber, string_types):
+                chamber = {chamber}
+            if not all(item in self.chambers for item in chamber):
+                raise ValueError(
+                    'all values in `chamber` must be valid; see `CapitolWords.chambers`')
+        if congress:
+            if isinstance(congress, int):
+                congress = {congress}
+            if not all(item in self.congresses for item in congress):
+                raise ValueError(
+                    'all values in `congress` must be valid; see `CapitolWords.congresses`')
+        if date_range:
+            if not isinstance(date_range, (list, tuple)):
+                raise ValueError('`date_range` must be a list or tuple, not %s', type(date_range))
+            if not len(date_range) == 2:
+                raise ValueError('`date_range` must have both start and end values')
+            if not date_range[0]:
+                date_range = (MIN_DATE, date_range[1])
+            if not date_range[1]:
+                date_range = (date_range[0], MAX_DATE)
+
+        n = 0
         mode = 'rb' if PY2 else 'rt'
         for line in read_json_lines(self.filepath, mode=mode):
-            yield line
+            if speaker_name and line['speaker_name'] not in speaker_name:
+                continue
+            if speaker_party and line['speaker_party'] not in speaker_party:
+                continue
+            if chamber and line['chamber'] not in chamber:
+                continue
+            if congress and line['congress'] not in congress:
+                continue
+            if date_range and not date_range[0] <= line['date'] <= date_range[1]:
+                continue
+            if min_len and len(line['text']) < min_len:
+                continue
+
+            if text_only is True:
+                yield line['text']
+            else:
+                yield line
+
+            n += 1
+            if n == limit:
+                break
 
     def texts(self, speaker_name=None, speaker_party=None, chamber=None,
               congress=None, date_range=None, min_len=None, limit=-1):
         """
         Iterate over texts in the CapitolWords corpus, optionally filtering by
-        a variety of metadata and/or text length.
+        a variety of metadata and/or text length, in order of date.
 
         Args:
-            speaker_name (str or set[str])
-            speaker_party (str or set[str])
-            chamber (str or set[str])
-            congress (int or set[int])
-            date_range (list[str] or tuple[str])
-            min_len (int)
-            limit (int)
+            speaker_name (str or set[str]): filter speeches by the speakers'
+                name; see :meth:`speaker_names <CapitolWords.speaker_names>`
+            speaker_party (str or set[str]): filter speeches by the speakers'
+                party; see :meth:`speaker_parties <CapitolWords.speaker_parties>`
+            chamber (str or set[str]): filter speeches by the chamber in which
+                they were given; see :meth:`chambers <CapitolWords.chambers>`
+            congress (int or set[int]): filter speeches by the congress in which
+                they were given; see :meth:`congresses <CapitolWords.congresses>`
+            date_range (list[str] or tuple[str]): filter speeches by the date on
+                which they were given; both start and end date must be specified,
+                but a null value for either will be replaced by the min/max date
+                available in the corpus
+            min_len (int): filter speeches by the length (number of characters)
+                in their text content
+            limit (int): return no more than `limit` speeches, in order of date
 
         Yields:
             str
@@ -148,69 +218,36 @@ class CapitolWords(object):
         Raises:
             ValueError
         """
-        # prepare filters
-        if speaker_name:
-            if isinstance(speaker_name, string_types):
-                speaker_name = {speaker_name}
-            if not all(item in self.speaker_names for item in speaker_name):
-                raise ValueError()
-        if speaker_party:
-            if isinstance(speaker_party, string_types):
-                speaker_party = {speaker_party}
-            if not all(item in self.speaker_parties for item in speaker_party):
-                raise ValueError()
-        if chamber:
-            if isinstance(chamber, string_types):
-                chamber = {chamber}
-            if not all(item in self.chambers for item in chamber):
-                raise ValueError()
-        if congress:
-            if isinstance(congress, int):
-                congress = {congress}
-            if not all(item in self.congresses for item in congress):
-                raise ValueError()
-        if date_range:
-            if not isinstance(date_range, (list, tuple)):
-                raise ValueError()
-            if not len(date_range) == 2:
-                raise ValueError()
-
-        n = 0
-        for doc in self:
-
-            if speaker_name and doc['speaker_name'] not in speaker_name:
-                continue
-            if speaker_party and doc['speaker_party'] not in speaker_party:
-                continue
-            if chamber and doc['chamber'] not in chamber:
-                continue
-            if congress and doc['congress'] not in congress:
-                continue
-            if date_range and not date_range[0] <= doc['date'] <= date_range[1]:
-                continue
-            if min_len and len(doc['text']) < min_len:
-                continue
-
-            yield doc['text']
-
-            n += 1
-            if n == limit:
-                break
+        texts = self._iterate(
+            True, speaker_name=speaker_name, speaker_party=speaker_party,
+            chamber=chamber, congress=congress, date_range=date_range,
+            min_len=min_len, limit=limit)
+        for text in texts:
+            yield text
 
     def docs(self, speaker_name=None, speaker_party=None, chamber=None,
              congress=None, date_range=None, min_len=None, limit=-1):
         """
         Iterate over documents (including text and metadata) in the CapitolWords
-        corpus, optionally filtering by a variety of metadata and/or text length.
+        corpus, optionally filtering by a variety of metadata and/or text length,
+        in order of date.
 
         Args:
-            speaker_name (str or set[str])
-            speaker_party (str or set[str])
-            chamber (str or set[str])
-            congress (int or set[int])
-            date_range (list[str] or tuple[str])
-            min_len (int)
-            limit (int)
+            speaker_name (str or set[str]): filter speeches by the speakers'
+                name; see :meth:`speaker_names <CapitolWords.speaker_names>`
+            speaker_party (str or set[str]): filter speeches by the speakers'
+                party; see :meth:`speaker_parties <CapitolWords.speaker_parties>`
+            chamber (str or set[str]): filter speeches by the chamber in which
+                they were given; see :meth:`chambers <CapitolWords.chambers>`
+            congress (int or set[int]): filter speeches by the congress in which
+                they were given; see :meth:`congresses <CapitolWords.congresses>`
+            date_range (list[str] or tuple[str]): filter speeches by the date on
+                which they were given; both start and end date must be specified,
+                but a null value for either will be replaced by the min/max date
+                available in the corpus
+            min_len (int): filter speeches by the length (number of characters)
+                in their text content
+            limit (int): return no more than `limit` speeches, in order of date
 
         Yields:
             dict
@@ -218,51 +255,9 @@ class CapitolWords(object):
         Raises:
             ValueError
         """
-        # prepare filters
-        if speaker_name:
-            if isinstance(speaker_name, string_types):
-                speaker_name = {speaker_name}
-            if not all(item in self.speaker_names for item in speaker_name):
-                raise ValueError()
-        if speaker_party:
-            if isinstance(speaker_party, string_types):
-                speaker_party = {speaker_party}
-            if not all(item in self.speaker_parties for item in speaker_party):
-                raise ValueError()
-        if chamber:
-            if isinstance(chamber, string_types):
-                chamber = {chamber}
-            if not all(item in self.chambers for item in chamber):
-                raise ValueError()
-        if congress:
-            if isinstance(congress, int):
-                congress = {congress}
-            if not all(item in self.congresses for item in congress):
-                raise ValueError()
-        if date_range:
-            if not isinstance(date_range, (list, tuple)):
-                raise ValueError()
-            if not len(date_range) == 2:
-                raise ValueError()
-
-        n = 0
-        for doc in self:
-
-            if speaker_name and doc['speaker_name'] not in speaker_name:
-                continue
-            if speaker_party and doc['speaker_party'] not in speaker_party:
-                continue
-            if chamber and doc['chamber'] not in chamber:
-                continue
-            if congress and doc['congress'] not in congress:
-                continue
-            if date_range and not date_range[0] <= doc['date'] <= date_range[1]:
-                continue
-            if min_len and len(doc['text']) < min_len:
-                continue
-
+        docs = self._iterate(
+            False, speaker_name=speaker_name, speaker_party=speaker_party,
+            chamber=chamber, congress=congress, date_range=date_range,
+            min_len=min_len, limit=limit)
+        for doc in docs:
             yield doc
-
-            n += 1
-            if n == limit:
-                break

--- a/textacy/corpora/capitolwords.py
+++ b/textacy/corpora/capitolwords.py
@@ -1,3 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+The CapitolWords Corpus
+-----------------------
+
+Download to and stream from disk a corpus of (almost all) speeches given by the
+main protagonists of the 2016 U.S. Presidential election that had previously
+served in the U.S. Congress — including Hillary Clinton, Bernie Sanders, Barack
+Obama, Ted Cruz, and John Kasich — between January 1996 and June 2016.
+
+The corpus contains over 11k documents comprised of nearly 7M tokens. Each
+document contains 7 fields:
+
+    * text: full(?) text of the speech
+    * title: title of the speech, in all caps
+    * date: date on which the speech was given, as an ISO-standard string
+    * speaker_name: first and last name of the speaker
+    * speaker_party: political party of the speaker ('R' for Republican, 'D' for
+      Democrat, and 'I' for Independent)
+    * congress: number of the Congress in which the speech was given; ranges
+      continuously between 104 and 114
+    * chamber: chamber of Congress in which the speech was given; almost all are
+      either 'House' or 'Senate', with a small number of 'Extensions'
+
+The source for this corpus is the Sunlight Foundation's
+`Capitol Words API <http://sunlightlabs.github.io/Capitol-Words/>`_.
+"""
 import os
 
 from textacy import __data_dir__
@@ -7,7 +34,20 @@ from textacy.fileio import read_json_lines
 
 class CapitolWords(object):
     """
-    TODO
+    TODO.
+
+    Args:
+        data_dir (str)
+
+    Attributes:
+        speaker_names (set[str]): full names of all speakers included in corpus,
+            e.g. `'Bernie Sanders'`
+        speaker_parties (set[str]): all distinct political parties of speakers,
+            e.g. `'R'`
+        chambers (set[str]): all distinct chambers in which speeches were given,
+            e.g. `'House'`
+        congresses (set[int]): all distinct numbers of the congresses in which
+            speeches were given, e.g. `114`
     """
 
     speaker_names = {

--- a/textacy/corpora/capitolwords.py
+++ b/textacy/corpora/capitolwords.py
@@ -1,0 +1,171 @@
+import os
+
+from textacy import __data_dir__
+from textacy.compat import PY2, string_types
+from textacy.fileio import read_json_lines
+
+
+class CapitolWords(object):
+    """
+    TODO
+    """
+
+    speaker_names = {
+        'Barack Obama', 'Bernie Sanders', 'Hillary Clinton', 'Jim Webb', 'Joe Biden',
+        'John Kasich', 'Joseph Biden', 'Lincoln Chafee', 'Lindsey Graham', 'Marco Rubio',
+        'Mike Pence', 'Rand Paul', 'Rick Santorum', 'Ted Cruz'}
+    speaker_parties = {'R', 'D', 'I'}
+    chambers = {'Extensions', 'House', 'Senate'}
+    congresses = {104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114}
+
+    def __init__(self, data_dir=None):
+        if data_dir is None:
+            data_dir = __data_dir__
+        if PY2:
+            self.filepath = os.path.join(data_dir, 'capitol-words.json')
+        else:
+            self.filepath = os.path.join(data_dir, 'capitol-words.json.gz')
+
+    def __iter__(self):
+        for line in read_json_lines(self.filepath, mode='rt'):
+            yield line
+
+    def texts(self, speaker_name=None, speaker_party=None, chamber=None,
+              congress=None, date_range=None, min_len=None, limit=-1):
+        """
+        Iterate over texts in the CapitolWords corpus, optionally filtering by
+        a variety of metadata and/or text length.
+
+        Args:
+            speaker_name (str or set[str])
+            speaker_party (str or set[str])
+            chamber (str or set[str])
+            congress (int or set[int])
+            date_range (list[str] or tuple[str])
+            min_len (int)
+            limit (int)
+
+        Yields:
+            str
+
+        Raises:
+            ValueError
+        """
+        # prepare filters
+        if speaker_name:
+            if isinstance(speaker_name, string_types):
+                speaker_name = {speaker_name}
+            if not all(item in self.speaker_names for item in speaker_name):
+                raise ValueError()
+        if speaker_party:
+            if isinstance(speaker_party, string_types):
+                speaker_party = {speaker_party}
+            if not all(item in self.speaker_parties for item in speaker_party):
+                raise ValueError()
+        if chamber:
+            if isinstance(chamber, string_types):
+                chamber = {chamber}
+            if not all(item in self.chambers for item in chamber):
+                raise ValueError()
+        if congress:
+            if isinstance(congress, int):
+                congress = {congress}
+            if not all(item in self.congresses for item in congress):
+                raise ValueError()
+        if date_range:
+            if not isinstance(date_range, (list, tuple)):
+                raise ValueError()
+            if not len(date_range) == 2:
+                raise ValueError()
+
+        n = 0
+        for doc in self:
+
+            if speaker_name and doc['speaker_name'] not in speaker_name:
+                continue
+            if speaker_party and doc['speaker_party'] not in speaker_party:
+                continue
+            if chamber and doc['chamber'] not in chamber:
+                continue
+            if congress and doc['congress'] not in congress:
+                continue
+            if date_range and not date_range[0] <= doc['date'] <= date_range[1]:
+                continue
+            if min_len and len(doc['text']) < min_len:
+                continue
+
+            yield doc['text']
+
+            n += 1
+            if n == limit:
+                break
+
+    def docs(self, speaker_name=None, speaker_party=None, chamber=None,
+             congress=None, date_range=None, min_len=None, limit=-1):
+        """
+        Iterate over documents (including text and metadata) in the CapitolWords
+        corpus, optionally filtering by a variety of metadata and/or text length.
+
+        Args:
+            speaker_name (str or set[str])
+            speaker_party (str or set[str])
+            chamber (str or set[str])
+            congress (int or set[int])
+            date_range (list[str] or tuple[str])
+            min_len (int)
+            limit (int)
+
+        Yields:
+            str
+
+        Raises:
+            ValueError
+        """
+        # prepare filters
+        if speaker_name:
+            if isinstance(speaker_name, string_types):
+                speaker_name = {speaker_name}
+            if not all(item in self.speaker_names for item in speaker_name):
+                raise ValueError()
+        if speaker_party:
+            if isinstance(speaker_party, string_types):
+                speaker_party = {speaker_party}
+            if not all(item in self.speaker_parties for item in speaker_party):
+                raise ValueError()
+        if chamber:
+            if isinstance(chamber, string_types):
+                chamber = {chamber}
+            if not all(item in self.chambers for item in chamber):
+                raise ValueError()
+        if congress:
+            if isinstance(congress, int):
+                congress = {congress}
+            if not all(item in self.congresses for item in congress):
+                raise ValueError()
+        if date_range:
+            if not isinstance(date_range, (list, tuple)):
+                raise ValueError()
+            if not len(date_range) == 2:
+                raise ValueError()
+
+        n = 0
+        for doc in self:
+
+            if speaker_name and doc['speaker_name'] not in speaker_name:
+                continue
+            if speaker_party and doc['speaker_party'] not in speaker_party:
+                continue
+            if chamber and doc['chamber'] not in chamber:
+                continue
+            if congress and doc['congress'] not in congress:
+                continue
+            if date_range and not date_range[0] <= doc['date'] <= date_range[1]:
+                continue
+            if min_len and len(doc['text']) < min_len:
+                continue
+
+            yield doc
+
+            n += 1
+            if n == limit:
+                break

--- a/textacy/corpora/capitolwords.py
+++ b/textacy/corpora/capitolwords.py
@@ -46,10 +46,45 @@ LOGGER = logging.getLogger(__name__)
 
 class CapitolWords(object):
     """
-    TODO: usage example.
+    Download data and stream from disk a collection of Congressional speeches
+    that includes the full text and key metadata for each::
+
+        >>> cw = textacy.corpora.CapitolWords()
+        >>> for text in cw.texts(limit=10):
+        ...     print(text)
+        >>> for doc in cw.docs(limit=10):
+        ...     print(doc['title'], doc['date'])
+        ...     print(doc['text'])
+
+    Filter speeches by metadata and text length::
+
+        >>> for doc in cw.docs(speaker_name='Bernie Sanders', limit=1):
+        ...     print(doc['date'], doc['text'])
+        >>> for doc in cw.docs(speaker_party='D', congress={110, 111, 112},
+        ...                    chamber='Senate', limit=10):
+        ...     print(doc['speaker_name'], doc['title'])
+        >>> for doc in cw.docs(speaker_name={'Barack Obama', 'Hillary Clinton'},
+        ...                    date_range=('2002-01-01', '2002-12-31')):
+        ...     print(doc['speaker_name'], doc['title'], doc['date'])
+        >>> for text in cw.texts(min_len=50000):
+        ...     print(len(text))
+
+    Stream speeches into a `TextCorpus`::
+
+        >>> text_stream, metadata_stream = textacy.fileio.split_content_and_metadata(
+        ...     cw.docs(limit=100), 'text')
+        >>> tc = textacy.TextCorpus.from_texts('en', text_stream, metadata_stream)
+        >>> print(tc)
 
     Args:
-        data_dir (str)
+        data_dir (str): path on disk containing corpus data; if None, textacy's
+            default `__resources_dir__` is used
+        download_if_missing (bool): if True and corpus data file isn't found on
+            disk, download the file and save it to disk under `data_dir`
+
+    Raises:
+        OSError: if corpus data file isn't found under `data_dir` and
+            `download_if_missing` is False
 
     Attributes:
         speaker_names (set[str]): full names of all speakers included in corpus,
@@ -178,7 +213,7 @@ class CapitolWords(object):
             limit (int)
 
         Yields:
-            str
+            dict
 
         Raises:
             ValueError

--- a/textacy/data.py
+++ b/textacy/data.py
@@ -26,7 +26,7 @@ from textacy.compat import PY2, bytes_type
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_DATA_DIR = textacy.__data_dir__
+DEFAULT_DATA_DIR = textacy.__resources_dir__
 
 _CACHE = {}
 """dict: key-value store used to cache datasets and such in memory"""

--- a/textacy/fileio/utils.py
+++ b/textacy/fileio/utils.py
@@ -51,7 +51,7 @@ def open_sesame(filepath, mode='rt',
     filepath = os.path.realpath(os.path.expanduser(filepath))
     if auto_make_dirs is True:
         make_dirs(filepath, mode)
-    elif not os.path.exists(filepath):
+    elif 'r' in mode and not os.path.exists(filepath):
         raise OSError('file "{}" does not exist'.format(filepath))
 
     # infer compression from filepath extension

--- a/textacy/texts.py
+++ b/textacy/texts.py
@@ -17,7 +17,7 @@ from spacy.tokens.doc import Doc as sdoc
 from spacy.tokens.token import Token as stoken
 from spacy.tokens.span import Span as sspan
 
-from textacy.compat import PY2, unicode_type, zip
+from textacy.compat import PY2, string_types, unicode_type, zip
 from textacy import (data, extract, fileio, keyterms, spacy_utils,
                      text_stats, text_utils)
 from textacy.representations import network, vsm
@@ -54,7 +54,7 @@ class TextDoc(object):
         self.metadata = {} if metadata is None else metadata
         self._term_counts = Counter()
 
-        if isinstance(text_or_sdoc, unicode_type):
+        if isinstance(text_or_sdoc, string_types):
             self.lang = text_utils.detect_language(text_or_sdoc) if not lang else lang
             if spacy_pipeline is None:
                 spacy_pipeline = data.load_spacy(self.lang)
@@ -749,7 +749,7 @@ class TextCorpus(object):
     specified by a function (e.g. ``TextCorpus.get_docs(lambda x: len(x) > 100)``).
     """
     def __init__(self, lang_or_pipeline):
-        if isinstance(lang_or_pipeline, unicode_type):
+        if isinstance(lang_or_pipeline, string_types):
             self.lang = lang_or_pipeline
             self.spacy_pipeline = data.load_spacy(self.lang)
         else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the CapitolWords corpus, a collection of 11k speeches (~7M tokens) given by the main protagonists of the 2016 U.S. Presidential election that had previously served in the U.S. Congress — including Hillary Clinton, Bernie Sanders, Barack Obama, Ted Cruz, and John Kasich — from January 1996 through June 2016.

Deprecated the Bernie and Hillary corpus, which is a small subset of CapitolWords that can be easily recreated by filtering CapitolWords by `speaker_name={'Bernie Sanders', 'Hillary Clinton'}`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted a larger and more easily subsetted corpus included with `textacy` that took advantage of the new compressed fileio, didn't rely on S3 for hosting, and whose interface was more in-line with the Wiki and Reddit corpora. It deprecates the existing Bernie and Hillary corpus because it's a strict superset of that corpus, which is nice. See Issue #27 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added lots of tests to a TestCase, and they all pass. 🙌 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
