### PR TITLE
Added delimited format fileio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backports.csv>=1.0.1
 backports.lzma>=0.0.6
 cachetools
 cld2-cffi>=0.1.3

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
 
     packages=find_packages(),
     install_requires=[
+        'backports.csv>=1.0.1',
         'backports.lzma>=0.0.6',
         'cachetools',
         'cld2-cffi>=0.1.3',

--- a/tests/test_corpora_bernie_and_hillary.py
+++ b/tests/test_corpora_bernie_and_hillary.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -36,6 +37,4 @@ class BernieAndHillaryTestCase(unittest.TestCase):
         self.assertNotEqual(bnh[0]['date'], '1996-01-04')
 
     def tearDown(self):
-        for fname in os.listdir(self.tempdir):
-            os.remove(os.path.join(self.tempdir, fname))
-        os.rmdir(self.tempdir)
+        shutil.rmtree(self.tempdir)

--- a/tests/test_corpora_reddit_reader.py
+++ b/tests/test_corpora_reddit_reader.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -57,6 +58,4 @@ class RedditReaderTestCase(unittest.TestCase):
         self.assertEqual(len(comments), 1)
 
     def tearDown(self):
-        for fname in os.listdir(self.tempdir):
-            os.remove(os.path.join(self.tempdir, fname))
-        os.rmdir(self.tempdir)
+        shutil.rmtree(self.tempdir)

--- a/tests/test_corpora_wiki_reader.py
+++ b/tests/test_corpora_wiki_reader.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -181,6 +182,4 @@ class WikiReaderTestCase(unittest.TestCase):
         self.assertEqual(len(pages), 1)
 
     def tearDown(self):
-        for fname in os.listdir(self.tempdir):
-            os.remove(os.path.join(self.tempdir, fname))
-        os.rmdir(self.tempdir)
+        shutil.rmtree(self.tempdir)

--- a/tests/test_topic_model.py
+++ b/tests/test_topic_model.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -99,6 +100,4 @@ class TopicModelTestCase(unittest.TestCase):
                 self.assertTrue(term_weights[i][1] >= term_weights[i+1][1])
 
     def tearDown(self):
-        for fname in os.listdir(self.tempdir):
-            os.remove(os.path.join(self.tempdir, fname))
-        os.rmdir(self.tempdir)
+        shutil.rmtree(self.tempdir)

--- a/textacy/compat.py
+++ b/textacy/compat.py
@@ -3,6 +3,7 @@ import sys
 PY2 = int(sys.version[0]) == 2
 
 if PY2:
+    from backports import csv
     from backports import lzma
     from itertools import izip as zip
 
@@ -17,6 +18,7 @@ if PY2:
         return unicode_type(b, encoding=encoding, errors=errors)
 
 else:
+    import csv
     import lzma
 
     zip = zip

--- a/textacy/fileio/__init__.py
+++ b/textacy/fileio/__init__.py
@@ -1,8 +1,8 @@
 from .utils import (coerce_content_type, get_filenames, open_sesame, make_dirs,
                     split_content_and_metadata, unzip)
-from .read import (read_json, read_json_lines, read_json_mash,
+from .read import (read_csv, read_json, read_json_lines, read_json_mash,
                    read_file, read_file_lines, read_spacy_docs,
                    read_sparse_csr_matrix, read_sparse_csc_matrix)
-from .write import (write_json, write_json_lines,
+from .write import (write_csv, write_json, write_json_lines,
                     write_file, write_file_lines, write_spacy_docs,
                     write_sparse_matrix)

--- a/textacy/fileio/read.py
+++ b/textacy/fileio/read.py
@@ -11,6 +11,7 @@ from numpy import load as np_load
 from scipy.sparse import csc_matrix, csr_matrix
 from spacy.tokens.doc import Doc as SpacyDoc
 
+from textacy.compat import csv
 from textacy.fileio import open_sesame
 
 JSON_DECODER = json.JSONDecoder()
@@ -125,6 +126,33 @@ def read_json_mash(filepath, mode='rt', encoding=None, buffersize=2048):
                 # not enough data to decode => read another chunk
                 except ValueError:
                     break
+
+
+def read_csv(filepath, encoding=None, dialect='excel', delimiter=','):
+    """
+    Iterate over a stream of rows, where each row is an iterable of strings
+    and/or numbers with individual values separated by ``delimiter``.
+
+    Args:
+        filepath (str): /path/to/file on disk from which rows will be streamed
+        encoding (str)
+        dialect (str): a grouping of formatting parameters that determine how
+            the tabular data is parsed when reading/writing; if 'infer', the
+            first 1024 bytes of the file is analyzed, producing a best guess for
+            the correct dialect
+        delimiter (str): 1-character string used to separate fields in a row
+
+    Yields:
+        List[obj]: next row, whose elements are strings and/or numbers
+
+    .. seealso:: https://docs.python.org/3/library/csv.html#csv.reader
+    """
+    with open_sesame(filepath, mode='rt', encoding=encoding, newline='') as f:
+        if dialect == 'infer':
+            dialect = csv.Sniffer().sniff(f.read(1024))
+            f.seek(0)
+        for row in csv.reader(f, dialect=dialect, delimiter=delimiter):
+            yield row
 
 
 def read_spacy_docs(spacy_vocab, filepath):

--- a/textacy/fileio/write.py
+++ b/textacy/fileio/write.py
@@ -9,7 +9,7 @@ from numpy import savez, savez_compressed
 from scipy.sparse import csc_matrix, csr_matrix
 from spacy.tokens.doc import Doc as SpacyDoc
 
-from textacy.compat import unicode_to_bytes
+from textacy.compat import csv, unicode_to_bytes
 from textacy.fileio import open_sesame, make_dirs
 
 
@@ -105,6 +105,40 @@ def write_json_lines(json_objects, filepath, mode='wt', encoding=None,
                                sort_keys=sort_keys) + newline)
 
 
+def write_csv(rows, filepath, encoding=None, auto_make_dirs=False,
+              dialect='excel', delimiter=',', ):
+    """
+    Iterate over a sequence of rows, where each row is an iterable of strings
+    and/or numbers, writing each to a separate line in file ``filepath`` with
+    individual values separated by ``delimiter``.
+
+    Args:
+        rows (Iterable[Iterable]): iterable of iterables of strings and/or
+            numbers to write to disk; for example::
+
+                [['That was a great movie!', 0.9],
+                 ['The movie was okay, I guess.', 0.2],
+                 ['Worst. Movie. Ever.', -1.0]]
+
+        filepath (str): /path/to/file on disk where rows will be written
+        encoding (str)
+        auto_make_dirs (bool)
+        dialect (str): a grouping of formatting parameters that determine how
+            the tabular data is parsed when reading/writing
+        delimiter (str): 1-character string used to separate fields in a row
+
+    .. seealso:: https://docs.python.org/3/library/csv.html#csv.writer
+
+    .. note:: Here, CSV is used as a catch-all term for *any* delimited file
+        format, and `delimiter=','` is merely the function's default value.
+        Other common delimited formats are TSV (tab-separated-value, with
+        `delimiter='\t''`) and PSV (pipe-separated-value, with `delimiter='|'`.
+    """
+    with open_sesame(filepath, mode='wt', encoding=encoding, newline='') as f:
+        csv_writer = csv.writer(f, dialect=dialect, delimiter=delimiter)
+        csv_writer.writerows(rows)
+
+
 def write_spacy_docs(spacy_docs, filepath, auto_make_dirs=False):
     """
     Serialize a sequence of ``spacy.Doc`` s to disk at ``filepath`` using Spacy's
@@ -113,7 +147,7 @@ def write_spacy_docs(spacy_docs, filepath, auto_make_dirs=False):
     Args:
         spacy_docs (``spacy.Doc`` or iterable(``spacy.Doc``)): a single spacy doc
             or a sequence of spacy docs to serialize to disk at ``filepath``
-        filepath (str): /path/to/file on disk from which spacy docs will be streamed
+        filepath (str): /path/to/file on disk to which spacy docs will be streamed
         auto_make_dirs (bool)
     """
     if isinstance(spacy_docs, SpacyDoc):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added functions to read and write delimited file formats: `read_csv()` and `write_csv()`, where the delimiter can be any valid one-char string; gzip/bzip/lzma compression is handled automatically, as usual
- Added `backports.csv` dependency to get Python 2 up to parity with Python 3's stdlib

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm thinking ahead to training models, and a common way of storing, say, observations of both features and labels, is in delimited files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests to `test_fileio.py`, and it works as advertised in both Python 2 and 3.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.