### PR TITLE
Import matplotlib locally

### DIFF
--- a/textacy/viz/network.py
+++ b/textacy/viz/network.py
@@ -4,9 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import math
 
-import matplotlib.pyplot as plt
-import networkx as nx
-
 
 RC_PARAMS = {'axes.axisbelow': True,
              'axes.edgecolor': '.8',
@@ -61,6 +58,9 @@ def draw_semantic_network(graph, node_weights=None, spread=3.0,
     Returns:
         ``matplotlib.axes.Axes.axis``: axis on which network plot is drawn
     """
+    import matplotlib.pyplot as plt
+    import networkx as nx
+
     with plt.rc_context(RC_PARAMS):
         fig, ax = plt.subplots(figsize=(12, 12))
 

--- a/textacy/viz/termite.py
+++ b/textacy/viz/termite.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 
@@ -96,6 +95,7 @@ def draw_termite_plot(values_mat, col_labels, row_labels,
         highlight_colors = {hc: COLOR_PAIRS[i]
                             for i, hc in enumerate(highlight_cols)}
 
+    import matplotlib.pyplot as plt
     with plt.rc_context(RC_PARAMS):
         fig, ax = plt.subplots(figsize=(pow(n_cols, 0.8), pow(n_rows, 0.66)))
 


### PR DESCRIPTION
## Description
Import matplotlib only in the functions where they are required rather than at the top of each module.

## Motivation and Context
Hi and thank you for your great work on this project. I am running textacy on a headless server and I would like to avoid installing matplotlib. It is a rather large download and is not needed for what I am doing (or for 95% of textacy for that matter). Even if I were willing to install it, it still takes a bit of setup to get it to run on a headless machine.

I am proposing to import matplotlib only in the functions where it is required. That way people who do not want to use the plotting features do not have to install an extra dependency. One might argue local imports are not that pythonic, but I think in this case this is the least invasive way of achieving what I need.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran changed version on a headless server without matplotlib.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Notes
I am a huge fan of optional dependencies. It would be nice if textacy had fewer dependencies,  or if dependencies were restricted to small parts of the application so that most of textacy can run without them. For example, gensim is required for its wiki reader, but I do not need to read wiki corpora. I will have to install gensim anyway. The same goes for networkx, requests and pyemd.
