### PR TITLE
Bugfix for the wiki_reader

### DIFF
--- a/textacy/corpora/wiki_reader.py
+++ b/textacy/corpora/wiki_reader.py
@@ -32,7 +32,6 @@ import ftfy
 from textacy.compat import PY2, bytes_to_unicode, unicode_
 from textacy.fileio import open_sesame
 
-
 re_nowiki = re.compile(r'<nowiki>(.*?)</nowiki>', flags=re.UNICODE)  # nowiki tags: take contents verbatim
 
 self_closing_tags = ('br', 'hr', 'nobr', 'ref', 'references')
@@ -154,7 +153,9 @@ class WikiReader(object):
                         content = ''
                     else:
                         content = elem.find(text_path).text
-                    if not isinstance(content, unicode_):
+                    if content is None:
+                        content = ''
+                    elif not isinstance(content, unicode_):
                         content = bytes_to_unicode(content, errors='ignore')
                     yield page_id, title, content
                     elem.clear()
@@ -344,7 +345,7 @@ def strip_markup(wikitext):
     # text = replace_internal_links(text)  # TODO: is this needed?
 
     # remove table markup
-    text = text.replace('||', '\n|').replace('!!', '\n!')  #  put each cell on a separate line
+    text = text.replace('||', '\n|').replace('!!', '\n!')  # put each cell on a separate line
     text = re_table_formatting.sub('\n', text)  # remove formatting lines
     text = re_table_cell_formatting.sub('\n\\3', text)  # leave only cell content
 


### PR DESCRIPTION
Bugfix for reading Wikipedia dumps

## Description
Using `wiki_reader.py` for parsing the Hungarian wikipedia throws an error.

## Motivation and Context

Parsing the Hungarian dump throws this error:

```
  File "./corpus-utils/wiki2txt.py", line 76, in <module>
    plac.call(main)
  File "/home/gorosz/miniconda3/envs/spacy-dev/lib/python2.7/site-packages/plac_core.py", line 328, in call
    cmd, result = parser.consume(arglist)
  File "/home/gorosz/miniconda3/envs/spacy-dev/lib/python2.7/site-packages/plac_core.py", line 207, in consume
    return cmd, self.func(*(args + varargs + extraopts), **kwargs)
  File "./corpus-utils/wiki2txt.py", line 66, in main
    for id, title, content in tqdm(reader):
  File "/home/gorosz/miniconda3/envs/spacy-dev/lib/python2.7/site-packages/tqdm/_tqdm.py", line 833, in __iter__
    for obj in iterable:
  File "/home/gorosz/miniconda3/envs/spacy-dev/lib/python2.7/site-packages/textacy/corpora/wiki_reader.py", line 158, in __iter__
    content = bytes_to_unicode(content, errors='ignore')
  File "/home/gorosz/miniconda3/envs/spacy-dev/lib/python2.7/site-packages/textacy/compat.py", line 17, in bytes_to_unicode
    return unicode_type(b, encoding=encoding, errors=errors)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```
## How Has This Been Tested?

Now it can parse the huwiki dump.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
