### PR TITLE
Expose ngrams in sgrank method

### DIFF
--- a/tests/test_keyterms.py
+++ b/tests/test_keyterms.py
@@ -80,6 +80,25 @@ class ExtractTestCase(unittest.TestCase):
         # for e, o in zip(expected, observed):
         #     self.assertEqual(e, o)
 
+    def test_sgrank_ngrams_1(self):
+        expected = [
+            'friedman', 'international', 'beirut', 'bureau', 'york']
+        observed = [term for term, _ in keyterms.sgrank(self.spacy_doc, ngrams=1, n_keyterms=5)]
+        self.assertEqual(len(expected), len(observed))
+        # can't do this owing to randomness of results
+        # for e, o in zip(expected, observed):
+        #     self.assertEqual(e, o)
+
+    def test_sgrank_ngrams_1_2_3(self):
+        expected = [
+            'new york times', 'friedman', 'pulitzer prize', 'beirut', 
+            'international reporting']
+        observed = [term for term, _ in keyterms.sgrank(self.spacy_doc, ngrams=(1, 2, 3), n_keyterms=5)]
+        self.assertEqual(len(expected), len(observed))
+        # can't do this owing to randomness of results
+        # for e, o in zip(expected, observed):
+        #     self.assertEqual(e, o)
+
     def test_sgrank_n_keyterms(self):
         expected = [
             'new york times', 'new york times jerusalem bureau chief', 'friedman',

--- a/textacy/keyterms.py
+++ b/textacy/keyterms.py
@@ -21,12 +21,15 @@ from textacy.network import terms_to_semantic_network
 from textacy.similarity import token_sort_ratio
 
 
-def sgrank(doc, normalize='lemma', window_width=1500, n_keyterms=10, idf=None):
+def sgrank(doc, ngrams=(1, 2, 3, 4, 5, 6), normalize='lemma', window_width=1500, n_keyterms=10, idf=None):
     """
     Extract key terms from a document using the [SGRank]_ algorithm.
 
     Args:
         doc (``textacy.Doc`` or ``spacy.Doc``)
+        ngrams (int or Set[int]): n of which n-grams to include; ``(1, 2, 3, 4, 5, 6)``
+                (default) includes all ngrams from 1 to 6; `2`
+                if only bigrams are wanted
         normalize (str or callable): If 'lemma', lemmatize terms; if 'lower',
             lowercase terms; if None, use the form of terms as they appeared in
             ``doc``; if a callable, must accept a ``spacy.Span`` and return a str,
@@ -65,6 +68,8 @@ def sgrank(doc, normalize='lemma', window_width=1500, n_keyterms=10, idf=None):
         raise ValueError('`window_width` must be >= 2')
     window_width = min(n_toks, window_width)
     min_term_freq = min(n_toks // 1000, 4)
+    if isinstance(ngrams, int):
+            ngrams = (ngrams,)
 
     # build full list of candidate terms
     # if inverse doc freqs available, include nouns, adjectives, and verbs;
@@ -74,7 +79,7 @@ def sgrank(doc, normalize='lemma', window_width=1500, n_keyterms=10, idf=None):
     terms = itertoolz.concat(
         extract.ngrams(doc, n, filter_stops=True, filter_punct=True, filter_nums=False,
                        include_pos=include_pos, min_freq=min_term_freq)
-        for n in range(1, 7))
+        for n in ngrams)
 
     # get normalized term strings, as desired
     # paired with positional index in document and length in a 3-tuple


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow ngrams to be passed as a parameter to the `keyterms.sgrank` method.
Also set the default ngrams to be in the range from 1 to 6 to be consistent with the paper.

## Motivation and Context
This allows more flexibility to the end user to be able to configure the ngrams range of interest. Also the end user can potentially improve performance by choosing to generate less ngrams. Also, the implementation is now consistent with the paper with the update to the default ngram range.

## How Has This Been Tested?
Tests are included and are in the style of your own.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
