### PR TITLE
DOC Add conda installation instructions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,13 @@ The simple way to install ``textacy`` is
 
     $ pip install textacy
 
-**Note:** Some dependencies have been made optional, because they can be difficult to install and/or are only needed in certain uses cases. To use viz functions, you'll need ``matplotlib`` installed; you can do so via ``pip install textacy[viz]``. For automatic language detection, you'll need ``cld2-cffi`` installed; do ``pip install textacy[lang]``. To install all optional dependencies:
+or using ``conda``
+
+.. code-block:: console
+
+    $ conda install -c conda-forge textacy
+
+**Note:** If you use ``pip``, some dependencies have been made optional, because they can be difficult to install and/or are only needed in certain uses cases. To use viz functions, you'll need ``matplotlib`` installed; you can do so via ``pip install textacy[viz]``. For automatic language detection, you'll need ``cld2-cffi`` installed; do ``pip install textacy[lang]``. To install all optional dependencies:
 
 .. code-block:: console
 


### PR DESCRIPTION
This adds [conda](https://conda.io) installation instructions. The packages are maintained by [conda-forge](https://conda-forge.github.io/) community.

You can accept this changes if you are OK with endorsing the ``conda-forge`` channel. Packages are not automatically updated, they require a PR following these instructions: https://github.com/conda-forge/textacy-feedstock#updating-textacy-feedstock