### PR TITLE
Python 2 : explicit about unicode for language

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,7 +66,7 @@ Efficiently stream documents from disk and into a processed corpus:
     >>> docs = cw.records(speaker_name={'Hillary Clinton', 'Barack Obama'})
     >>> content_stream, metadata_stream = textacy.fileio.split_record_fields(
     ...     docs, 'text')
-    >>> corpus = textacy.Corpus('en', texts=content_stream, metadatas=metadata_stream)
+    >>> corpus = textacy.Corpus('en', texts=content_stream, metadatas=metadata_stream) ### Python 2 - use u'en'
     >>> corpus
     Corpus(1241 docs; 857058 tokens)
 


### PR DESCRIPTION
corpus = textacy.Corpus(u'en', texts=text_stream, metadatas=metadata_stream) ### for Python 2 the language attribute needs to be unicode

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
