### PR TITLE
Encoding UTF-8 on open_sesame

### DIFF
--- a/textacy/corpora/wiki_reader.py
+++ b/textacy/corpora/wiki_reader.py
@@ -126,10 +126,10 @@ class WikiReader(object):
         """
         if is_python2 is False:
             events = ('end',)
-            f = open_sesame(self.path, mode='rt')
+            f = open_sesame(self.path, mode='rt', encoding="UTF-8")
         else:  # Python 2 can't open bzip in text mode :(
             events = (b'end',)
-            f = open_sesame(self.path, mode='rb')
+            f = open_sesame(self.path, mode='rb', encoding="UTF-8")
         with f:
 
             elems = (elem for _, elem in iterparse(f, events=events))

--- a/textacy/corpora/wiki_reader.py
+++ b/textacy/corpora/wiki_reader.py
@@ -129,7 +129,7 @@ class WikiReader(object):
             f = open_sesame(self.path, mode='rt', encoding="UTF-8")
         else:  # Python 2 can't open bzip in text mode :(
             events = (b'end',)
-            f = open_sesame(self.path, mode='rb', encoding="UTF-8")
+            f = open_sesame(self.path, mode='rb')
         with f:
 
             elems = (elem for _, elem in iterparse(f, events=events))


### PR DESCRIPTION
Hi I was unable to use it on windows, without adding the encoding.

## Description
Adding encoding on reader

## Motivation and Context
It was not working on windows

## How Has This Been Tested?
Just used to generate wikidump (from xml.bz2 to txt)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
