### PR TITLE
Fix terms overlap test in doc.to_terms_list

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -114,8 +114,8 @@ class ReadmeTestCase(unittest.TestCase):
         # sort by term ascending, then count descending
         observed_2 = sorted(bot.items(), key=itemgetter(1, 0), reverse=True)[:10]
         expected_2 = [
-            ('nation', 6), ('world', 4), ('u.s.', 4), ('incarceration', 4),
-            ('decade', 4), ('system', 3), ('state', 3), ('record', 3),
-            ('problem', 3), ('people', 3)]
+            ('nation', 6), ('world', 4), ('incarceration', 4), ('system', 3),
+            ('state', 3), ('problem', 3), ('people', 3), ('minimum', 3),
+            ('mandatory', 3), ('lead', 3)]
         self.assertEqual(observed_1, expected_1)
         self.assertEqual(observed_2, expected_2)

--- a/textacy/doc.py
+++ b/textacy/doc.py
@@ -472,7 +472,7 @@ class Doc(object):
                 if n == 1:
                     terms.append(
                         (word for word in textacy.extract.words(self, **ngram_kwargs)
-                         if (word.idx, word.idx + 1) not in ent_idxs))
+                         if (word.i, word.i + 1) not in ent_idxs))
                 else:
                     terms.append(
                         (ngram for ngram in textacy.extract.ngrams(self, n, **ngram_kwargs)


### PR DESCRIPTION
Use token index instead of character offset when testing for overlap between named entities and uni-grams.

## How Has This Been Tested?
```
doc = textacy.Doc('old Hollywood movies')
list(doc.to_terms_list(as_strings=True))
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
