### PR TITLE
fixing corpus example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ Efficiently stream documents from disk and into a processed corpus:
 .. code-block:: pycon
 
     >>> cw = textacy.datasets.CapitolWords()
+    >>> cw.download()
     >>> records = cw.records(speaker_name={'Hillary Clinton', 'Barack Obama'})
     >>> text_stream, metadata_stream = textacy.fileio.split_record_fields(
     ...     records, 'text')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The corpus example doesn't work, as cw.download() is needed to actually load the corpus.

## Motivation and Context
Basic installation of textacy does not download the corpora, so the first example does not work as is. cw.download() must be called to get the code to run. 

https://github.com/chartbeat-labs/textacy/issues/123

## How Has This Been Tested?
Just a simple change to the readme. Ran the code and works as tested. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation, and I have updated it accordingly.
