### PR TITLE
Add group to PHONE_REGEX for easier interpretation

### DIFF
--- a/textacy/constants.py
+++ b/textacy/constants.py
@@ -45,7 +45,7 @@ PUNCT_TRANSLATE_BYTES = ''.join(
 
 ACRONYM_REGEX = re.compile(r"(?:^|(?<=\W))(?:(?:(?:(?:[A-Z]\.?)+[a-z0-9&/-]?)+(?:[A-Z][s.]?|[0-9]s?))|(?:[0-9](?:\-?[A-Z])+))(?:$|(?=\W))", flags=re.UNICODE)
 EMAIL_REGEX = re.compile(r"(?:^|(?<=[^\w@.)]))([\w+-](\.(?!\.))?)*?[\w+-]@(?:\w-?)*?\w+(\.([a-z]{2,})){1,3}(?:$|(?=\b))", flags=re.IGNORECASE | re.UNICODE)
-PHONE_REGEX = re.compile(r'(?:^|(?<=[^\w)]))(\+?1[ .-]?)?(\(?\d{3}\)?[ .-]?)?\d{3}[ .-]?\d{4}(\s?(?:ext\.?|[#x-])\s?\d{2,6})?(?:$|(?=\W))')
+PHONE_REGEX = re.compile(r'(?:^|(?<=[^\w)]))(\+?1[ .-]?)?(\(?\d{3}\)?[ .-]?)?(\d{3}[ .-]?\d{4})(\s?(?:ext\.?|[#x-])\s?\d{2,6})?(?:$|(?=\W))')
 NUMBERS_REGEX = re.compile(r'(?:^|(?<=[^\w,.]))[+–-]?(([1-9]\d{0,2}(,\d{3})+(\.\d*)?)|([1-9]\d{0,2}([ .]\d{3})+(,\d*)?)|(\d*?[.,]\d+)|\d+)(?:$|(?=\b))')
 CURRENCY_REGEX = re.compile('[{0}]+'.format(''.join(CURRENCIES.keys())))
 LINEBREAK_REGEX = re.compile(r'((\r\n)|[\n\v])+')


### PR DESCRIPTION
For re operations that output groups, like findall(), the compulsory
part of the phone number is left out. Including it is useful when trying
out the pattern outside of the module.

<!--- Provide a general summary of your changes in the Title above -->

## Description

## Motivation and Context
When testing out `PHONE_REGEX` for myself, I was getting output like:
```
>>> PHONE_REGEX.findall('000-111-222')
[('', '000-', '')]
```
where optional parts of pattern are split, but compulsory is missing.
New output: `[('', '000-', '111-2222', '')]`

## How Has This Been Tested?
Ran unittests with test_contansts.py.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
