### PR TITLE
add custom pipeline components to new "spacier" sub-package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/build/*
 # testing
 .cache
 .coverage
+.pytest_cache/
 
 # textacy
 resources/

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -98,17 +98,17 @@ Visualization
 Utilities
 ---------
 
+.. automodule:: textacy.cache
+    :members:
+
 .. automodule:: textacy.text_utils
     :members:
 
 .. automodule:: textacy.spacy_utils
     :members:
 
-.. automodule:: textacy.math_utils
-    :members:
-
-Other Stuff!
-------------
+Miscellany
+----------
 
 .. automodule:: textacy.network
     :members:
@@ -119,8 +119,11 @@ Other Stuff!
 .. automodule:: textacy.text_stats
     :members:
 
-.. automodule:: textacy.cache
+.. automodule:: textacy.lexicon_methods
     :members:
 
-.. automodule:: textacy.lexicon_methods
+Spacier
+-------
+
+.. automodule:: textacy.spacier.components
     :members:

--- a/tests/test_spacier_components.py
+++ b/tests/test_spacier_components.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, unicode_literals
+
+import os
+
+import pytest
+
+from textacy import cache
+from textacy import spacier
+
+TEXT = (
+    'The year was 2081, and everybody was finally equal. '
+    'They weren\'t only equal before God and the law. '
+    'They were equal every which way.')
+
+
+@pytest.fixture(scope='module')
+def spacy_lang():
+    spacy_lang = cache.load_spacy('en')
+    text_stats_component = spacier.components.TextStatsComponent()
+    spacy_lang.add_pipe(text_stats_component, after='parser')
+
+    yield spacy_lang
+
+    # remove component after running these tests
+    spacy_lang.remove_pipe('textacy_text_stats')
+
+
+@pytest.fixture(scope='module')
+def spacy_doc(spacy_lang):
+    spacy_doc = spacy_lang(TEXT)
+    return spacy_doc
+
+
+def test_component_name(spacy_lang):
+    assert spacy_lang.has_pipe('textacy_text_stats') is True
+
+
+def test_component_attrs():
+    attrs_args = [
+        None,
+        'flesch_kincaid_grade_level',
+        ['flesch_kincaid_grade_level', 'flesch_reading_ease'],
+    ]
+    for attrs in attrs_args:
+        text_stats_component = spacier.components.TextStatsComponent(attrs=attrs)
+        assert isinstance(text_stats_component.attrs, tuple) is True
+
+
+def test_attrs_on_doc(spacy_lang, spacy_doc):
+    tsc = spacy_lang.get_pipe('textacy_text_stats')
+    for attr in tsc.attrs:
+        assert spacy_doc._.has(attr) is True
+        assert isinstance(spacy_doc._.get(attr), (int, float, dict)) is True

--- a/tests/test_spacier_components.py
+++ b/tests/test_spacier_components.py
@@ -51,3 +51,16 @@ def test_attrs_on_doc(spacy_lang, spacy_doc):
     for attr in tsc.attrs:
         assert spacy_doc._.has(attr) is True
         assert isinstance(spacy_doc._.get(attr), (int, float, dict)) is True
+
+
+def test_merge_entities(spacy_lang):
+    doc1 = spacy_lang('Matthew Honnibal and Ines Montani do great work spaCy.')
+    # (temporarily) add this other component to the pipeline
+    spacy_lang.add_pipe(spacier.components.merge_entities, after='ner')
+    doc2 = spacy_lang('Matthew Honnibal and Ines Montani do great work spaCy.')
+    # check the key behaviors we'd expect
+    assert spacy_lang.has_pipe('merge_entities') is True
+    assert len(doc1) > len(doc2)
+    assert any(tok.text == 'Matthew Honnibal' for tok in doc2)
+    # now remove this component, since we don't want it elsewhere
+    spacy_lang.remove_pipe('merge_entities')

--- a/textacy/spacier/__init__.py
+++ b/textacy/spacier/__init__.py
@@ -1,0 +1,1 @@
+from .components import TextStatsComponent

--- a/textacy/spacier/components.py
+++ b/textacy/spacier/components.py
@@ -1,0 +1,83 @@
+"""
+Custom components to add to a spaCy language pipeline.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+from spacy.tokens import Doc as SpacyDoc
+
+from .. import compat
+from .. import text_stats
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TextStatsComponent(object):
+    """
+    A custom component to be added to a spaCy language pipeline that computes
+    one, some, or all text stats for a parsed doc and sets the values
+    as custom attributes on a :obj:`SpacyDoc`.
+
+    Add the component to a pipeline, *after* the parser::
+
+        >>> en = spacy.load('en')
+        >>> text_stats_component = TextStatsComponent()
+        >>> en.add_pipe(text_stats_component, after='parser')
+
+    Process a text with the pipeline and access the custom attributes via
+    spaCy's underscore syntax::
+
+        >>> doc = en(u"This is a test test someverylongword.")
+        >>> doc._.n_words
+        6
+        >>> doc._.flesch_reading_ease
+        73.84500000000001
+
+    Specify which attributes of the :class:`textacy.text_stats.TextStats()`
+    to add to processed documents::
+
+        >>> en = spacy.load('en')
+        >>> text_stats_component = TextStatsComponent(attrs='n_words')
+        >>> en.add_pipe(text_stats_component, after='parser')
+        >>> doc = en(u"This is a test test someverylongword.")
+        >>> doc._.n_words
+        6
+        >>> doc._.flesch_reading_ease
+        AttributeError: [E046] Can't retrieve unregistered extension attribute 'flesch_reading_ease'. Did you forget to call the `set_extension` method?
+
+    Args:
+        attrs (str or Iterable[str] or None): If str, a single text stat
+            to compute and set on a :obj:`Doc`. If Iterable[str], multiple
+            text stats. If None, *all* text stats are computed and set as extensions.
+
+    See Also:
+        :class:`textacy.text_stats.TextStats`
+    """
+
+    name = 'textacy_text_stats'
+
+    def __init__(self, attrs=None):
+        if attrs is None:
+            self.attrs = (
+                'n_sents', 'n_words', 'n_chars', 'n_syllables',
+                'n_unique_words', 'n_long_words',
+                'n_monosyllable_words', 'n_polysyllable_words',
+                'flesch_kincaid_grade_level', 'flesch_reading_ease',
+                'smog_index', 'gunning_fog_index', 'coleman_liau_index',
+                'automated_readability_index', 'lix', 'gulpease_index',
+                'wiener_sachtextformel',
+            )
+        elif isinstance(attrs, compat.string_types):
+            self.attrs = (attrs,)
+        else:
+            self.attrs = tuple(attrs)
+        for attr in self.attrs:
+            SpacyDoc.set_extension(attr, default=None)
+            LOGGER.debug('"%s" custom attribute added to `spacy.tokens.Doc`')
+
+    def __call__(self, doc):
+        ts = text_stats.TextStats(doc)
+        for attr in self.attrs:
+            doc._.set(attr, getattr(ts, attr))
+        return doc

--- a/textacy/spacier/components.py
+++ b/textacy/spacier/components.py
@@ -113,7 +113,7 @@ def merge_entities(doc):
         Burton DeWilde
 
     Args:
-        doc (``SpacyDoc`)
+        doc (``SpacyDoc``)
 
     Returns:
         ``SpacyDoc``: Input ``doc`` with merged entities.

--- a/textacy/spacy_pipelines.py
+++ b/textacy/spacy_pipelines.py
@@ -3,7 +3,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
+from . import utils
+
 LOGGER = logging.getLogger(__name__)
+
+utils.deprecated(
+    "The `spacy_pipelines` module is deprecated and will be removed in v0.7.0."
+    "Use the `textacy.spacier` subpackage instead.",
+    action='once')
 
 
 def _merge_entities(doc):

--- a/textacy/spacy_utils.py
+++ b/textacy/spacy_utils.py
@@ -1,4 +1,7 @@
 """
+spaCy Utils
+-----------
+
 Set of small utility functions that take Spacy objects as input.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/textacy/text_utils.py
+++ b/textacy/text_utils.py
@@ -1,4 +1,7 @@
 """
+Text Utils
+----------
+
 Set of small utility functions that take text strings as input.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Creates a new sub-package called `spacier` (ha) in which to consolidate spaCy-focused functionality.
- Adds a `components` module to `spacier` for custom spaCy language pipeline components, and includes two to start: one that computes text stats via the `TextStats` class, and another that merges named entities into a single token using spaCy's new `Doc.retokenize` functionality.
- Marks the `spacy_pipelines` module for deprecation in v0.7.0.

More functionality to come, this is just a non-feature-breaking down payment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature request from Ines in #168. 🙂 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added tests, and they all pass. Huzzah.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
