### PR TITLE
Fix most_discriminating_terms in keyterms

### DIFF
--- a/tests/test_keyterms.py
+++ b/tests/test_keyterms.py
@@ -251,3 +251,31 @@ def test_singlegrank_norm_normalized_str(spacy_doc):
     # can't do this owing to randomness of results
     # for e, o in zip(expected, observed):
     #     asert e == o
+
+def test_most_discriminating_terms(spacy_doc):
+    text1 = """Friedman joined the London bureau of United Press International after completing his master's degree. He was dispatched a year later to Beirut, where he lived from June 1979 to May 1981 while covering the Lebanon Civil War. He was hired by The New York Times as a reporter in 1981 and re-dispatched to Beirut at the start of the 1982 Israeli invasion of Lebanon. His coverage of the war, particularly the Sabra and Shatila massacre, won him the Pulitzer Prize for International Reporting (shared with Loren Jenkins of The Washington Post). Alongside David K. Shipler he also won the George Polk Award for foreign reporting.
+    In June 1984, Friedman was transferred to Jerusalem, where he served as the New York Times Jerusalem Bureau Chief until February 1988. That year he received a second Pulitzer Prize for International Reporting, which cited his coverage of the First Palestinian Intifada. He wrote a book, From Beirut to Jerusalem, describing his experiences in the Middle East, which won the 1989 U.S. National Book Award for Nonfiction.
+    Friedman covered Secretary of State James Baker during the administration of President George H. W. Bush. Following the election of Bill Clinton in 1992, Friedman became the White House correspondent for the New York Times. In 1994, he began to write more about foreign policy and economics, and moved to the op-ed page of The New York Times the following year as a foreign affairs columnist. In 2002, Friedman won the Pulitzer Prize for Commentary for his "clarity of vision, based on extensive reporting, in commenting on the worldwide impact of the terrorist threat."
+    In February 2002, Friedman met Saudi Crown Prince Abdullah and encouraged him to make a comprehensive attempt to end the Arab-Israeli conflict by normalizing Arab relations with Israel in exchange for the return of refugees alongside an end to the Israel territorial occupations. Abdullah proposed the Arab Peace Initiative at the Beirut Summit that March, which Friedman has since strongly supported.
+    Friedman received the 2004 Overseas Press Club Award for lifetime achievement and was named to the Order of the British Empire by Queen Elizabeth II.
+    In May 2011, The New York Times reported that President Barack Obama "has sounded out" Friedman concerning Middle East issues."""
+    
+    text2 = """In 1954, Bucksbaum and his brother Martin borrowed $1.2 million and built the first shopping center in Cedar Rapids, Iowa, anchored by a fourth family grocery store.
+    They expanded into enclosed malls which mirrored the continued movement to the suburbs seen in the 1960s.
+    By 1964, their company - then named General Management - owned five malls anchored by the Younkers department store.
+    In 1972, the company became publicly traded on the New York Stock Exchange under the name General Growth Properties and became the second-largest owner, developer, and manager of regional shopping malls in the country.
+    Bucksbaum served as its Chairman and Chief Executive Officer and under his tenure, he formed two Real estate investment trusts and expanded the company's portfolio of malls and shopping centers via more than $36 billion in acquisitions.
+    In 1984, General Growth sold 19 malls for $800 million to Equitable Real Estate, which was deemed the “nation’s largest single asset real estate transaction” to date.
+    In 1995, his brother Martin died and he re-located the company to Chicago.
+    In 2004, General Growth purchased The Rouse Company for $14.2 billion.
+    By 2007, General Growth was the second-largest REIT owning 194 malls with over 200 million square feet in 44 states.
+    In 2008, General Growth filed for Chapter 11 bankruptcy protection after the collapse of the stock market."""
+
+    doc1 = [line.split() for line in text1.split('\n')]
+    doc2 = [line.split() for line in text2.split('\n')]
+
+    expected = (['Friedman', 'Times'], ['General', 'malls'])
+    observed = keyterms.most_discriminating_terms(doc1 + doc2, [True] * len(doc1) + [False] * len(doc2), top_n_terms=2)
+    
+    print(observed)
+    assert expected == observed

--- a/textacy/keyterms.py
+++ b/textacy/keyterms.py
@@ -370,21 +370,20 @@ def most_discriminating_terms(terms_lists, bool_array_grp1,
     bool_array_grp2 = np.invert(bool_array_grp1)
 
     vectorizer = vsm.Vectorizer(
-        weighting='tf', normalize=False,
-        sublinear_tf=False, smooth_idf=True,
-        min_df=3, max_df=0.95, min_ic=0.0, max_n_terms=max_n_terms)
+        tf_type='linear', norm=None, idf_type='smooth',
+        min_df=3, max_df=0.95, max_n_terms=max_n_terms)
     dtm = vectorizer.fit_transform(terms_lists)
     id2term = vectorizer.id_to_term
 
     # get doc freqs for all terms in grp1 documents
     dtm_grp1 = dtm[bool_array_grp1, :]
     n_docs_grp1 = dtm_grp1.shape[0]
-    doc_freqs_grp1 = vsm.get_doc_freqs(dtm_grp1, normalized=False)
+    doc_freqs_grp1 = vsm.get_doc_freqs(dtm_grp1)
 
     # get doc freqs for all terms in grp2 documents
     dtm_grp2 = dtm[bool_array_grp2, :]
     n_docs_grp2 = dtm_grp2.shape[0]
-    doc_freqs_grp2 = vsm.get_doc_freqs(dtm_grp2, normalized=False)
+    doc_freqs_grp2 = vsm.get_doc_freqs(dtm_grp2)
 
     # get terms that occur in a larger fraction of grp1 docs than grp2 docs
     term_ids_grp1 = np.where(doc_freqs_grp1 / n_docs_grp1 > doc_freqs_grp2 / n_docs_grp2)[0]


### PR DESCRIPTION
## Description
`keyterms.most_discriminating_terms` was broken, beause of changes introduced to `vsm.Vectorizer` and `get_doc_freqs` (introduced in #167 )

## Motivation and Context
I didn't make an issue for this, because it seemed like a straight forward fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A unit test was added to `test_keyterms.py`, because there was previously no coverage for the `most_discriminating_terms` method.
This was tested using pytest as standard: `pytest tests/test_keyterms.py -v`.


## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
