### PR TITLE
New feature allowing working with Wikinews media dumps

### DIFF
--- a/textacy/datasets/wikipedia.py
+++ b/textacy/datasets/wikipedia.py
@@ -22,7 +22,6 @@ from __future__ import unicode_literals
 import logging
 import os
 import re
-import sys
 from xml.etree.cElementTree import iterparse
 
 import ftfy

--- a/textacy/datasets/wikipedia.py
+++ b/textacy/datasets/wikipedia.py
@@ -153,7 +153,9 @@ class Wikipedia(Dataset):
             most recently available version or a date formatted as "YYYYMMDD".
             Dumps are produced intermittently; check for available versions at
             https://meta.wikimedia.org/wiki/Data_dumps.
-
+        project (str): Name or alias of wikimedia data dump you wish to work
+           with.  Currently 'wiki' (default) and 'wikinews' are supported with
+           respective aliases 'wikipedia' and 'news'.
     Attributes:
         lang (str): Standard two-letter language code used in instantiation.
         version (str): Database dump version used in instantiation.
@@ -161,6 +163,8 @@ class Wikipedia(Dataset):
             lang- and version-specific database dump.
         filename (str): Full path on disk for the lang- and version-specific
             Wikipedia database dump, found under the ``data_dir`` directory.
+        project (str): the canonical name for the wikimedia project which is
+            used as a component of ``filestub``.
     """
 
     def __init__(self, data_dir=DATA_DIR, lang='en', version='latest', project='wiki'):
@@ -170,7 +174,8 @@ class Wikipedia(Dataset):
         self.version = version
         proj = PROJECTS.get(project, None)
         if proj is None:
-            raise AttributeError('Invalid wikimedia project: {project}'.format(
+            raise AttributeError(
+                'Invalid or unsupported wikimedia project: {project}'.format(
                 project=project
             ))
         self.project = proj

--- a/textacy/extract.py
+++ b/textacy/extract.py
@@ -219,6 +219,9 @@ def named_entities(doc,
         nes = doc.spacy_doc.ents
     else:
         nes = doc.ents
+    # HACK: spacy's models have been erroneously tagging whitespace as entities
+    # https://github.com/explosion/spaCy/commit/1e6725e9b734862e61081a916baf440697b9971e
+    nes = (ne for ne in nes if not ne.text.isspace())
     include_types = _parse_ne_types(include_types, "include")
     exclude_types = _parse_ne_types(exclude_types, "exclude")
     if include_types:


### PR DESCRIPTION
I added a `project` named param with default value 'wiki' to the Wikipedia constructor, which allows one to specify a wikimedia project other than 'wikipedia'.  This PR only adds support for 'wikinews'.

## Description
* added a PROJECTS dictionary to allow lookup of values, allowing project aliases as well, and added exception handling for bad values
* actually a simple change.  `file_stub` format is now `'{lang}{project}/{version}/{lang}{project}-{version}-pages-articles.xml.bz2'`


## Motivation and Context
I wanted to work with Wikinews data dumps.  Other packages exist for extracting the page text but this project already performs category extraction, which is what I needed, so simply adding a simple feature to this project rather than a more complicated one to another project seemed to be my best option.
 
## How Has This Been Tested?
* As the feature is quite simple, I merely manually verified that the URLs generated by the modified `file_stub` value were still sane, and that my exception handling for unhandled values for the new `project` named param worked.
* I did *think* about defining  `_verify_url(url)` and calling it in `download()` just prior to the actual downloading of the URL, which would simply do a HEAD request, catch a 404 and then backoff to see if BASE_URL/{lang}{project} existed to determine what error message to provide in the case that whatever mediawiki project doesn't exist for a particular language, but figured I should talk with someone about this first.  This *would* provide a function which could be added to a unit test though.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation, and I have updated it accordingly.
