### PR TITLE
new feature allowing accessing records/text from Wikipedia other than namespace 0

### DIFF
--- a/textacy/datasets/wikipedia.py
+++ b/textacy/datasets/wikipedia.py
@@ -164,6 +164,7 @@ class Wikipedia(Dataset):
         self.filestub = '{lang}wiki/{version}/{lang}wiki-{version}-pages-articles.xml.bz2'.format(
             version=self.version, lang=self.lang)
         self._filename = os.path.join(data_dir, self.filestub)
+        self._extract_namespace = '0'
 
     @property
     def filename(self):
@@ -237,7 +238,7 @@ class Wikipedia(Dataset):
                     page_id = elem.find(page_id_path).text
                     title = elem.find(title_path).text
                     ns = elem.find(ns_path).text
-                    if ns != '0':
+                    if ns != self._extract_namespace:
                         content = ''
                     else:
                         content = elem.find(text_path).text
@@ -311,7 +312,7 @@ class Wikipedia(Dataset):
 
         return parsed_content
 
-    def texts(self, min_len=100, limit=-1):
+    def texts(self, min_len=100, limit=-1, namespace='0'):
         """
         Iterate over pages (text-only) in a Wikipedia database dump, optionally
         filtering by text length.
@@ -329,6 +330,7 @@ class Wikipedia(Dataset):
             Page and section titles appear immediately before the text content
             that they label, separated by an empty line.
         """
+        self._extract_namespace = namespace
         n_pages = 0
         for _, title, content in self:
             text = strip_markup(content)
@@ -341,7 +343,7 @@ class Wikipedia(Dataset):
             if n_pages == limit:
                 break
 
-    def records(self, min_len=100, limit=-1, fast=False):
+    def records(self, min_len=100, limit=-1, fast=False, namespace='0'):
         """
         Iterate over pages (parsed text and metadata) in a Wikipedia database dump,
         optionally filtering by text length.
@@ -361,6 +363,7 @@ class Wikipedia(Dataset):
         Note:
             This function requires `mwparserfromhell <mwparserfromhell.readthedocs.org>`_.
         """
+        self._extract_namespace = namespace
         try:
             mwparserfromhell
         except NameError:

--- a/textacy/datasets/wikipedia.py
+++ b/textacy/datasets/wikipedia.py
@@ -322,13 +322,16 @@ class Wikipedia(Dataset):
                 for it to be returned; too-short pages are skipped.
             limit (int): Maximum number of pages (passing ``min_len``) to yield;
                 if -1, all pages in the db dump are iterated over.
-
+            namespace (str): Allows one to specify a namespace other than '0'
+                (the default) to extract text from
         Yields:
             str: Full text of next page in the Wikipedia database dump.
 
-        Note:
+        Notes:
             Page and section titles appear immediately before the text content
             that they label, separated by an empty line.
+
+            Namespace values can be discoverd via ``bzcat dumpfile.xml.bz2 | head`` 
         """
         self._extract_namespace = namespace
         n_pages = 0
@@ -356,12 +359,15 @@ class Wikipedia(Dataset):
             fast (bool): If True, text is extracted using a faster method but
                 which gives lower quality results. Otherwise, a slower but better
                 method is used to extract article text.
-
+            namespace (str): Allows one to extract records from a namspace other
+                 than '0' (the default)
         Yields:
             dict: Parsed text and metadata of next page in the Wikipedia database dump.
 
-        Note:
+        Notes:
             This function requires `mwparserfromhell <mwparserfromhell.readthedocs.org>`_.
+
+            Namespace values can be discovered via ``bzcat dump_file.xml.bz2 | head``
         """
         self._extract_namespace = namespace
         try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
* added support for extracting records/text from namespaces other than '0'

## Description
<!--- Describe your changes in detail -->
* added new `namespace` param (default value '0') to `Wikipedia.records()` and `Wikipedia.text()`
* added to private attribute `self._extract_namespace` which gets set by each call to `records()` and `text()`
* replaced test in `__iter__()` from `if ns != '0':` to `if ns != self._extract_namespace:`
* updated docstrings for `records()` and `text()`, both describing the new parameter, and in the 'Notes'  section of the docstrings, described how to obtain namespace values from a dump file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to extract the categories associated with category pages (namespace 14 - in Wikinews at least), since a category's categories are it's *parent* categories, and I'm interested in the category structure.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've merely been using it since I've made my changes and know that I didn't break anything regarding it's use of the default namespace '0' and that it works for namespace '14' as well.  Without parsing the head of the raw document, I don't know how to verify whether the namespace value is valid, or what will happen if an invalid value is passed in, although I believe one will simply get a whole lot of nothing returned
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
