### PR TITLE
small change to catch bad wiki category markup

### DIFF
--- a/textacy/datasets/wikipedia.py
+++ b/textacy/datasets/wikipedia.py
@@ -303,16 +303,18 @@ class Wikipedia(Dataset):
 
         parsed_content = {}
         cat_link = MAPPING_CAT[self.lang]
+        # catch category links errantly marked up in lowercase
         lc_cat_link = cat_link.lower()
 
         wikilinks = [unicode_(wc.title) for wc in wikicode.ifilter_wikilinks()]
-        parsed_content['categories'] = [
+        categories = [
             wc for wc in wikilinks
             if wc.startswith(cat_link) or wc.startswith(lc_cat_link)
         ]
+        parsed_content['categories'] = categories
         parsed_content['wiki_links'] = [
             wc for wc in wikilinks
-            if not wc.startswith(MAPPING_CAT[self.lang]) and
+            if wc not in categories and
             not wc.startswith('File:') and
             not wc.startswith('Image:')]
         parsed_content['ext_links'] = [

--- a/textacy/datasets/wikipedia.py
+++ b/textacy/datasets/wikipedia.py
@@ -302,11 +302,14 @@ class Wikipedia(Dataset):
         wikicode = parser.parse(content)
 
         parsed_content = {}
+        cat_link = MAPPING_CAT[self.lang]
+        lc_cat_link = cat_link.lower()
 
         wikilinks = [unicode_(wc.title) for wc in wikicode.ifilter_wikilinks()]
         parsed_content['categories'] = [
             wc for wc in wikilinks
-            if wc.startswith(MAPPING_CAT[self.lang])]
+            if wc.startswith(cat_link) or wc.startswith(lc_cat_link)
+        ]
         parsed_content['wiki_links'] = [
             wc for wc in wikilinks
             if not wc.startswith(MAPPING_CAT[self.lang]) and


### PR DESCRIPTION
Although I imagine textacy shouldn't be involved in a cat and mouse game of handling bad wiki markup, this simple change allows for categories which are marked up in lower case to be caught, which accounts for a few thousand extra category links being recognized in a media wiki dump.
 
## Description
It simply searches, within the wiki_links extracted via mwparserfromhello, for both category links represented by (`MAPPING_CAT[self.lang]`) and the lower-case version of that string.
 
## Motivation and Context
It simply catches a larger portion of category links with a minimal cost in computation.

<!--- If it fixes an open issue, please link to the issue here. -->
This fixes Issue #222 which I created 

## How Has This Been Tested?
I don't know how to truly test this, as I suppose it's non-deterministic like natural language.  I don't know how many category links are still being missed, I can only confirm that there is a net increase in the number of categories recognized compared to the number of categories recognized prior to this simple change.

My testing of this is external to this code.  I use textacy's processing of namespace 0 and namespace 14 (categories) to create a `networkx.DiGraph` which represents the category hierarchy.  Basically, the resulting graph of categories produced by this fix has far fewer nodes which are isolates.
 
The change is harmless to the rest of the code, however due to my inability to compare the raw content to the markup-stripped content, I didn't modify the regexp used to remove category links via the `text()` method, meaning this only impacts the `records()` method.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
