### PR TITLE
Add additional flags to doc_extensions.to_bag_of_words

### DIFF
--- a/textacy/corpus.py
+++ b/textacy/corpus.py
@@ -401,7 +401,7 @@ class Corpus(object):
     # useful methods
 
     def word_counts(self, normalize="lemma", weighting="count", as_strings=False,
-                    filter_stop=True, filter_punct=True, filter_nums=False):
+                    filter_stops=True, filter_punct=True, filter_nums=False):
         """
         Map the set of unique words in :class:`Corpus` to their counts as
         absolute, relative, or binary frequencies of occurence, similar to
@@ -462,7 +462,7 @@ class Corpus(object):
 
     def word_doc_counts(
         self, normalize="lemma", weighting="count", smooth_idf=True, as_strings=False,
-        remove_stop=True, remove_punct=True, remove_space=True):
+        filter_stops=True, filter_punct=True, filter_nums=True):
         """
         Map the set of unique words in :class:`Corpus` to their *document* counts
         as absolute, relative, inverse, or binary frequencies of occurence.
@@ -483,9 +483,9 @@ class Corpus(object):
                 document to the corpus containing every unique word.
             as_strings (bool): If True, words are returned as strings; if False
                 (default), words are returned as their unique integer ids
-            remove_stop (bool): If True (default), stop word counts are removed.
-            remove_punct (bool): If True (default), punctuation counts are removed.
-            remove_space (bool): If True (default), whitespace counts are removed.
+            filter_stops (bool): If True (default), stop word counts are removed.
+            filter_punct (bool): If True (default), punctuation counts are removed.
+            filter_nums (bool): If True, number counts are removed.
 
         Returns:
             dict: mapping of a unique word id or string (depending on the value
@@ -501,8 +501,8 @@ class Corpus(object):
             word_doc_counts_.update(
                 doc._.to_bag_of_words(
                     normalize=normalize, weighting="binary", as_strings=as_strings,
-                    remove_stop=remove_stop, remove_punct=remove_punct, 
-                    remove_space=remove_space
+                    filter_stops=remove_stop, filter_punct=remove_punct, 
+                    filter_nums=remove_nums
                 )
             )
         if weighting == "count":

--- a/textacy/corpus.py
+++ b/textacy/corpus.py
@@ -461,7 +461,7 @@ class Corpus(object):
         return word_counts_
 
     def word_doc_counts(
-        self, normalize="lemma", weighting="count", smooth_idf=True, as_strings=False
+        self, normalize="lemma", weighting="count", smooth_idf=True, as_strings=False,
         remove_stop=True, remove_punct=True, remove_space=True):
         """
         Map the set of unique words in :class:`Corpus` to their *document* counts

--- a/textacy/corpus.py
+++ b/textacy/corpus.py
@@ -501,8 +501,8 @@ class Corpus(object):
             word_doc_counts_.update(
                 doc._.to_bag_of_words(
                     normalize=normalize, weighting="binary", as_strings=as_strings,
-                    filter_stops=remove_stop, filter_punct=remove_punct, 
-                    filter_nums=remove_nums
+                    filter_stops=filter_stops, filter_punct=filter_punct, 
+                    filter_nums=filter_nums
                 )
             )
         if weighting == "count":

--- a/textacy/corpus.py
+++ b/textacy/corpus.py
@@ -400,7 +400,8 @@ class Corpus(object):
 
     # useful methods
 
-    def word_counts(self, normalize="lemma", weighting="count", as_strings=False):
+    def word_counts(self, normalize="lemma", weighting="count", as_strings=False,
+                    remove_stop=True, remove_punct=True, remove_space=True):
         """
         Map the set of unique words in :class:`Corpus` to their counts as
         absolute, relative, or binary frequencies of occurence, similar to
@@ -423,6 +424,9 @@ class Corpus(object):
 
             as_strings (bool): If True, words are returned as strings; if False
                 (default), words are returned as their unique integer ids.
+            remove_stop (bool): If True (default), stop word counts are removed.
+            remove_punct (bool): If True (default), punctuation counts are removed.
+            remove_space (bool): If True (default), whitespace counts are removed.
 
         Returns:
             dict: mapping of a unique word id or string (depending on the value
@@ -436,7 +440,9 @@ class Corpus(object):
         for doc in self:
             word_counts_.update(
                 doc._.to_bag_of_words(
-                    normalize=normalize, weighting="count", as_strings=as_strings
+                    normalize=normalize, weighting="count", as_strings=as_strings,
+                    remove_stop=remove_stop, remove_punct=remove_punct, 
+                    remove_space=remove_space
                 )
             )
         if weighting == "count":
@@ -456,7 +462,7 @@ class Corpus(object):
 
     def word_doc_counts(
         self, normalize="lemma", weighting="count", smooth_idf=True, as_strings=False
-    ):
+        remove_stop=True, remove_punct=True, remove_space=True):
         """
         Map the set of unique words in :class:`Corpus` to their *document* counts
         as absolute, relative, inverse, or binary frequencies of occurence.
@@ -477,6 +483,9 @@ class Corpus(object):
                 document to the corpus containing every unique word.
             as_strings (bool): If True, words are returned as strings; if False
                 (default), words are returned as their unique integer ids
+            remove_stop (bool): If True (default), stop word counts are removed.
+            remove_punct (bool): If True (default), punctuation counts are removed.
+            remove_space (bool): If True (default), whitespace counts are removed.
 
         Returns:
             dict: mapping of a unique word id or string (depending on the value
@@ -491,7 +500,9 @@ class Corpus(object):
         for doc in self:
             word_doc_counts_.update(
                 doc._.to_bag_of_words(
-                    normalize=normalize, weighting="binary", as_strings=as_strings
+                    normalize=normalize, weighting="binary", as_strings=as_strings,
+                    remove_stop=remove_stop, remove_punct=remove_punct, 
+                    remove_space=remove_space
                 )
             )
         if weighting == "count":

--- a/textacy/corpus.py
+++ b/textacy/corpus.py
@@ -401,7 +401,7 @@ class Corpus(object):
     # useful methods
 
     def word_counts(self, normalize="lemma", weighting="count", as_strings=False,
-                    remove_stop=True, remove_punct=True, remove_space=True):
+                    filter_stop=True, filter_punct=True, filter_nums=False):
         """
         Map the set of unique words in :class:`Corpus` to their counts as
         absolute, relative, or binary frequencies of occurence, similar to
@@ -424,9 +424,9 @@ class Corpus(object):
 
             as_strings (bool): If True, words are returned as strings; if False
                 (default), words are returned as their unique integer ids.
-            remove_stop (bool): If True (default), stop word counts are removed.
-            remove_punct (bool): If True (default), punctuation counts are removed.
-            remove_space (bool): If True (default), whitespace counts are removed.
+            filter_stops (bool): If True (default), stop word counts are removed.
+            filter_punct (bool): If True (default), punctuation counts are removed.
+            filter_nums (bool): If True, number counts are removed.
 
         Returns:
             dict: mapping of a unique word id or string (depending on the value
@@ -441,8 +441,8 @@ class Corpus(object):
             word_counts_.update(
                 doc._.to_bag_of_words(
                     normalize=normalize, weighting="count", as_strings=as_strings,
-                    remove_stop=remove_stop, remove_punct=remove_punct, 
-                    remove_space=remove_space
+                    filter_stops=filter_stops, filter_punct=filter_punct, 
+                    filter_nums=filter_nums
                 )
             )
         if weighting == "count":

--- a/textacy/spacier/doc_extensions.py
+++ b/textacy/spacier/doc_extensions.py
@@ -464,7 +464,7 @@ def to_bag_of_terms(
 
 
 def to_bag_of_words(doc, normalize="lemma", weighting="count", as_strings=False, 
-                    remove_stop=True, remove_punct=True, remove_space=True):
+                    filter_stops=True, filter_punct=True, filter_nums=False):
     """
     Transform ``Doc`` into a bag-of-words: the set of unique words in ``Doc``
     mapped to their absolute, relative, or binary frequency of occurrence.
@@ -484,11 +484,11 @@ def to_bag_of_words(doc, normalize="lemma", weighting="count", as_strings=False,
             counts are normalized.
         as_strings (bool): If True, words are returned as strings; if False
             (default), words are returned as their unique integer ids
-        remove_stop (bool): If True (default), stop words are removed after
+        filter_stops (bool): If True (default), stop words are removed after
             counting.
-        remove_punct (bool): If True (default), punctuation tokens are removed
+        filter_punct (bool): If True (default), punctuation tokens are removed
             after counting.
-        remove_space (bool): If True (default), whitespace tokens are removed
+        filter_nums (bool): If True, tokens consisting of digits are removed
             after counting.
 
     Returns:
@@ -516,17 +516,19 @@ def to_bag_of_words(doc, normalize="lemma", weighting="count", as_strings=False,
     if as_strings is False:
         for wid, weight in wid_weights.items():
             lex = vocab[wid]
-            if not ( (lex.is_stop and remove_stop) or 
-                     (lex.is_punct and remove_punct) or 
-                     (lex.is_space and remove_space)):
+            if not ( (lex.is_stop and filter_stops) or 
+                     (lex.is_punct and filter_punct) or
+                     (lex.is_digit and filter_nums) or
+                      lex.is_space):
                 bow[wid] = weight
     else:
         ss = doc.vocab.strings
         for wid, weight in wid_weights.items():
             lex = vocab[wid]
-            if not ( (lex.is_stop and remove_stop) or 
-                     (lex.is_punct and remove_punct) or 
-                     (lex.is_space and remove_space) ):
+            if not ( (lex.is_stop and filter_stops) or 
+                     (lex.is_punct and filter_punct) or 
+                     (lex.is_digit and filter_nums) or
+                      lex.is_space):
                 bow[ss[wid]] = weight
     return bow
 

--- a/textacy/spacier/doc_extensions.py
+++ b/textacy/spacier/doc_extensions.py
@@ -463,7 +463,8 @@ def to_bag_of_terms(
     return bot
 
 
-def to_bag_of_words(doc, normalize="lemma", weighting="count", as_strings=False):
+def to_bag_of_words(doc, normalize="lemma", weighting="count", as_strings=False, 
+                    remove_stop=True, remove_punct=True, remove_space=True):
     """
     Transform ``Doc`` into a bag-of-words: the set of unique words in ``Doc``
     mapped to their absolute, relative, or binary frequency of occurrence.
@@ -481,8 +482,14 @@ def to_bag_of_words(doc, normalize="lemma", weighting="count", as_strings=False)
             Note: The resulting set of frequencies won't (necessarily) sum
             to 1.0, since punctuation and stop words are filtered out after
             counts are normalized.
-        as_strings (bool): if True, words are returned as strings; if False
+        as_strings (bool): If True, words are returned as strings; if False
             (default), words are returned as their unique integer ids
+        remove_stop (bool): If True (default), stop words are removed after
+            counting.
+        remove_punct (bool): If True (default), punctuation tokens are removed
+            after counting.
+        remove_space (bool): If True (default), whitespace tokens are removed
+            after counting.
 
     Returns:
         dict: mapping of a unique word id or string (depending on the value
@@ -509,13 +516,17 @@ def to_bag_of_words(doc, normalize="lemma", weighting="count", as_strings=False)
     if as_strings is False:
         for wid, weight in wid_weights.items():
             lex = vocab[wid]
-            if not (lex.is_stop or lex.is_punct or lex.is_space):
+            if not ( (lex.is_stop and remove_stop) or 
+                     (lex.is_punct and remove_punct) or 
+                     (lex.is_space and remove_space)):
                 bow[wid] = weight
     else:
         ss = doc.vocab.strings
         for wid, weight in wid_weights.items():
             lex = vocab[wid]
-            if not (lex.is_stop or lex.is_punct or lex.is_space):
+            if not ( (lex.is_stop and remove_stop) or 
+                     (lex.is_punct and remove_punct) or 
+                     (lex.is_space and remove_space) ):
                 bow[ss[wid]] = weight
     return bow
 


### PR DESCRIPTION
## Description
`doc_extensions.to_bag_of_words` has be modified to include additional flags that enable the user to decide whether or not to include/exclude stop words, punctuation and/or spaces from the word counts.

`Corpus.words_counts` and `Corpus.word_doc_counts` have also been updated to pass through the relevant flags to `doc_extensions.to_bag_of_words`.

## Motivation and Context
Sometimes it may be of interest to keep track of stop words, punctuation and/or spaces when converting a doc to a bag of words.

## How Has This Been Tested?
``` 
> d = "This is a test. This, here, is another test"
> doc = textacy.make_spacy_doc(d)

> textacy.spacier.doc_extensions.to_bag_of_words(doc, normalize="", as_strings=True)
{'test': 2}

> textacy.spacier.doc_extensions.to_bag_of_words(doc, normalize="", as_strings=True, remove_stop=False)
{'is': 2, 'This': 2, 'a': 1, 'here': 1, 'another': 1, 'test': 2}

textacy.spacier.doc_extensions.to_bag_of_words(doc, normalize="", as_strings=True, remove_stop=False, remove_punct=False)
{'!': 1, 'is': 2, 'This': 2, '.': 1, 'a': 1, 'here': 1, 'another': 1, 'test': 2, ',': 2}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
