### PR TITLE
Fix vsm.Vectorizer reference in quickstart docs

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -375,7 +375,7 @@ weighting, and filtering of terms:
 .. code-block:: pycon
 
     >>> import textacy.vsm  # note the import
-    >>> vectorizer = textacy.Vectorizer(
+    >>> vectorizer = textacy.vsm.Vectorizer(
     ...     tf_type="linear", apply_idf=True, idf_type="smooth", norm="l2",
     ...     min_df=2, max_df=0.95)
     >>> doc_term_matrix = vectorizer.fit_transform(


### PR DESCRIPTION
`Vectorizer` should be accessed via `textacy.vsm.Vectorizer`

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

