### PR TITLE
Support prepositional objects in SVO IE

### DIFF
--- a/src/textacy/spacier/utils.py
+++ b/src/textacy/spacier/utils.py
@@ -8,7 +8,7 @@ from typing import Iterable, List, Tuple, Union
 import numpy as np
 from spacy import attrs
 from spacy.language import Language
-from spacy.symbols import PROPN, VERB
+from spacy.symbols import PROPN, VERB, NOUN
 from spacy.tokens import Doc, Span, Token
 
 from .. import constants, errors, text_utils
@@ -158,6 +158,12 @@ def get_objects_of_verb(verb: Token) -> List[Token]:
     objs.extend(tok for tok in verb.rights if tok.dep_ == "xcomp")
     # get additional conjunct objects
     objs.extend(tok for obj in objs for tok in _get_conjuncts(obj))
+    # get additional prepositional objects
+    for tok in verb.rights:
+        if tok.dep_ == "prep":
+            for tok2 in tok.rights:
+                if tok2.pos in [PROPN, NOUN]:  # pragma: no cover
+                    objs.append(tok2)
     return objs
 
 

--- a/tests/spacier/test_spacier_utils.py
+++ b/tests/spacier/test_spacier_utils.py
@@ -94,7 +94,7 @@ def test_get_subjects_of_verb(spacy_doc):
 
 
 def test_get_objects_of_verb(spacy_doc):
-    expected = [[], ["Python"], ["incompatibilities"], [], ["God"]]
+    expected = [[], ["Python"], ["incompatibilities"], ["sake"], ["God", "Overflow"]]
     main_verbs = [
         tok for sent in spacy_doc.sents for tok in utils.get_main_verbs_of_sent(sent)
     ]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -297,6 +297,11 @@ class TestSubjectVerbObjectTriples:
         assert all(isinstance(span, Span) for triple in result for span in triple)
         assert all(any(tok.pos_ == "VERB" for tok in triple[1]) for triple in result)
 
+    def test_prepositions(self):
+        spacy_doc = load_spacy_lang("en")("Barack Obama was born in Hawaii.")
+        result = list(extract.subject_verb_object_triples(spacy_doc))
+        assert [(str(x[0]), str(x[1]), str(x[2])) for x in result] == [("Barack Obama", "was born", "Hawaii")]
+
 
 class TestAcronymsAndDefinitions:
 


### PR DESCRIPTION
Support the handling of prepositions when performing Subject-Verb-Object Information Extraction.

## Description
When running Subject-Verb-Object analysis the current program cannot handle looking past a preposition before a noun, and therefore cannot extract the Object correctly when there is a preposition in front of it.

## Motivation and Context
I was running this on a test string "Barack Obama was born in Hawaii." and failed to get a Subject-Verb-Object triple.

## How Has This Been Tested?
I run a modified version of textacy 0.10.1 that isolates the "subject_verb_object" function and has support for running on spacy 2.1.0. I tested this in this modified version and the input "Barack Obama was born in Hawaii." produces the triple ("Barack Obama", "born in", "Hawaii").

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
