### PR TITLE
docs: fix simple typo, inferrred -> inferred

### DIFF
--- a/src/textacy/io/utils.py
+++ b/src/textacy/io/utils.py
@@ -56,7 +56,7 @@ def open_sesame(
             Only applicable in text mode.
         compression: Type of compression, if any, with which ``filepath``
             is read from or written to disk. If None, no compression is used;
-            if 'infer', compression is inferrred from the extension on ``filepath``.
+            if 'infer', compression is inferred from the extension on ``filepath``.
         make_dirs: If True, automatically create (sub)directories
             if not already present in order to write ``filepath``.
 


### PR DESCRIPTION
There is a small typo in src/textacy/io/utils.py.

Should read `inferred` rather than `inferrred`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md