### PR TITLE
Fix import for TextStats

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -135,7 +135,8 @@ We can also identify key terms in a document by a number of algorithms:
 Or we can compute various basic and readability statistics:
 
 ```pycon
->>> ts = textacy.TextStats(doc)
+>>> from textacy.text_stats import TextStats
+>>> ts = TextStats(doc)
 >>> ts.n_words, ts.n_syllables, ts.n_chars
 (73, 134, 414)
 >>> ts.entropy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`TextStats` is documented as being directly with the root package `textacy`, but in my installation (version 0.11.0 installed via `pip` and Python 3.8) it's actually within `textacy.text_stats`.

## Motivation and Context

Accurate quickstart documentation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested only in a REPL (ptpython):

```python
>>> import textacy

>>> doc = textacy.make_spacy_doc("Hello, world!", lang="en_core_sci_md")

>>> ts = textacy.TextStats(doc)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'textacy' has no attribute 'TextStats'

module 'textacy' has no attribute 'TextStats'

>>> ts = textacy.text_stats.TextStats(doc)

>>> ts.n_words
2


>>>
```


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
