### PR TITLE
Bump python support from 3.7–3.9 to 3.8–3.10

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, "3.10"]
         os: [macos-latest, ubuntu-latest]  # windows-latest
 
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         os: [macos-latest, ubuntu-latest]  # windows-latest
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: set up Python 3.8
+    - name: set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.8

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -12,7 +12,7 @@ jobs:
     - name: set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: 3.8
     - name: install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 branches:
   # whitelist
   only:
-    - master
+    - main
 
 environment:
 
@@ -10,15 +10,16 @@ environment:
 
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
+    # (windows: https://www.appveyor.com/docs/windows-images-software/#python)
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install wheel"
+  - "%PYTHON%\\python.exe -m pip install build wheel"
 
 build: off
 
@@ -38,7 +39,7 @@ after_test:
   # Again, you only need build.cmd if you're building C extensions for
   # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
   # interpreter
-  - "%PYTHON%\\python.exe setup.py bdist_wheel"
+  - "%PYTHON%\\python.exe -m build --sdist --wheel"
 
 artifacts:
   # bdist_wheel puts your built wheel in the dist directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 89
-target-version = ["py37", "py38", "py39"]
+target-version = ["py38", "py39"]
 exclude = '''
 (
     src/textacy/preprocessing/resources.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,9 @@ classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Natural Language :: English
     Topic :: Text Processing :: Linguistic
 keywords =
@@ -36,7 +36,7 @@ project_urls =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     cachetools>=4.0.0
     cytoolz>=0.10.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- add support for PY3.10, drop support for PY3.7
- make PY3.8 the standard version used in workflows, packaging, etc.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Python 3.10 was released earlier this year, and since `spacy` (not to mention `numpy`, etc.) supports PY3.10, `textacy` should too. On the other end, we're dropping PY3.7 support to align with `numpy`'s supported versions convention and to take advantage of improvements made to `typing` in PY3.8.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
