### PR TITLE
Replace model short cut with full name

### DIFF
--- a/docs/source/walkthrough.md
+++ b/docs/source/walkthrough.md
@@ -223,7 +223,7 @@ For this and a few other datasets, convenient `Dataset` classes are already impl
 A `textacy.Corpus` is an ordered collection of spaCy `Doc` s, all processed by the same language pipeline. Let's continue with the Capitol Words dataset and make a corpus from a stream of records. (**Note:** This may take a few minutes.)
 
 ```pycon
->>> corpus = textacy.Corpus("en", data=records)
+>>> corpus = textacy.Corpus("en_core_web_sm", data=records)
 >>> corpus
 Corpus(1240 docs, 857548 tokens)
 ```

--- a/src/textacy/datasets/capitol_words.py
+++ b/src/textacy/datasets/capitol_words.py
@@ -87,7 +87,7 @@ class CapitolWords(Dataset):
 
     Stream speeches into a :class:`textacy.Corpus <textacy.corpus.Corpus>`::
 
-        >>> textacy.Corpus("en", data=ota.records(limit=100))
+        >>> textacy.Corpus("en_core_web_sm", data=ds.records(limit=100))
         Corpus(100 docs; 70496 tokens)
 
     Args:

--- a/src/textacy/datasets/imdb.py
+++ b/src/textacy/datasets/imdb.py
@@ -85,7 +85,7 @@ class IMDB(Dataset):
 
     Stream movie reviews into a :class:`textacy.Corpus <textacy.corpus.Corpus>`::
 
-        >>> textacy.Corpus("en", data=ds.records(limit=100))
+        >>> textacy.Corpus("en_core_web_sm", data=ds.records(limit=100))
         Corpus(100 docs; 24340 tokens)
 
     Args:

--- a/src/textacy/datasets/oxford_text_archive.py
+++ b/src/textacy/datasets/oxford_text_archive.py
@@ -83,7 +83,7 @@ class OxfordTextArchive(Dataset):
 
     Stream literary works into a :class:`textacy.Corpus <textacy.corpus.Corpus>`::
 
-        >>> textacy.Corpus("en", data=ds.records(limit=5))
+        >>> textacy.Corpus("en_core_web_sm", data=ds.records(limit=5))
         Corpus(5 docs; 182289 tokens)
 
     Args:

--- a/src/textacy/datasets/reddit_comments.py
+++ b/src/textacy/datasets/reddit_comments.py
@@ -83,7 +83,7 @@ class RedditComments(Dataset):
 
     Stream comments into a :class:`textacy.Corpus <textacy.corpus.Corpus>`::
 
-        >>> textacy.Corpus("en", data=ds.records(limit=1000))
+        >>> textacy.Corpus("en_core_web_sm", data=ds.records(limit=1000))
         Corpus(1000 docs; 27582 tokens)
 
     Args:

--- a/src/textacy/datasets/supreme_court.py
+++ b/src/textacy/datasets/supreme_court.py
@@ -111,7 +111,7 @@ class SupremeCourt(Dataset):
 
     Stream decisions into a :class:`textacy.Corpus <textacy.corpus.Corpus>`::
 
-        >>> textacy.Corpus("en", data=ds.records(limit=25))
+        >>> textacy.Corpus("en_core_web_sm", data=ds.records(limit=25))
         Corpus(25 docs; 136696 tokens)
 
     Args:

--- a/src/textacy/datasets/wikimedia.py
+++ b/src/textacy/datasets/wikimedia.py
@@ -414,7 +414,7 @@ class Wikipedia(Wikimedia):
 
     Stream wiki pages into a :class:`textacy.Corpus <textacy.corpus.Corpus>`::
 
-        >>> textacy.Corpus("en", data=ds.records(min_len=2000, limit=50))
+        >>> textacy.Corpus("en_core_web_sm", data=ds.records(min_len=2000, limit=50))
         Corpus(50 docs; 72368 tokens)
 
     Args:
@@ -483,7 +483,7 @@ class Wikinews(Wikimedia):
 
     Stream wiki pages into a :class:`textacy.Corpus <textacy.corpus.Corpus>`::
 
-        >>> textacy.Corpus("en", data=ds.records(limit=100))
+        >>> textacy.Corpus("en_core_web_sm", data=ds.records(limit=100))
         Corpus(100 docs; 33092 tokens)
 
     Args:


### PR DESCRIPTION
This commit replaces the model shortcut with the full name.

<!--- Provide a general summary of your changes in the Title above -->

## Description

The shortcut "en" results in an error.

> OSError: [E941] Can't find model 'en'. It looks like you're trying to load a model from a shortcut, which is obsolete as of spaCy v3.0. To load the model, use its full name instead:

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation, and I have updated it accordingly.
