### PR TITLE
extact is renamed to extract

### DIFF
--- a/src/textacy/extract/basics.py
+++ b/src/textacy/extract/basics.py
@@ -332,10 +332,10 @@ def terms(
         the top-ranking terms. There is no such scoring or ranking here.
 
     See Also:
-        - :func:`textacy.extact.ngrams()`
-        - :func:`textacy.extact.entities()`
-        - :func:`textacy.extact.noun_chunks()`
-        - :mod:`textacy.extact.keyterms`
+        - :func:`textacy.extract.ngrams()`
+        - :func:`textacy.extract.entities()`
+        - :func:`textacy.extract.noun_chunks()`
+        - :mod:`textacy.extract.keyterms`
     """
     extractors = _get_extractors(ngs, ents, ncs)
     terms_ = itertoolz.concat(extractor(doclike) for extractor in extractors)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The documentation mentions the method `textact.extact`, rather it should be `textacy.extract`, in `basics.py`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->'
Improve the documentation and clarity
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
`textacy.extract` exists and works instead of `textacy.extact`

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
